### PR TITLE
Uber artifacts should not include SLF4J related classes

### DIFF
--- a/runtime/standalone-shared/pom.xml
+++ b/runtime/standalone-shared/pom.xml
@@ -20,6 +20,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/runtime/standalone-sisu-uber/pom.xml
+++ b/runtime/standalone-sisu-uber/pom.xml
@@ -33,6 +33,11 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+          <artifactSet>
+            <excludes>
+              <exclude>org.slf4j:*</exclude>
+            </excludes>
+          </artifactSet>
           <filters>
             <filter>
               <artifact>*:*</artifact>

--- a/runtime/standalone-static-uber/pom.xml
+++ b/runtime/standalone-static-uber/pom.xml
@@ -33,6 +33,11 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+          <artifactSet>
+            <excludes>
+              <exclude>org.slf4j:*</exclude>
+            </excludes>
+          </artifactSet>
           <filters>
             <filter>
               <artifact>*:*</artifact>


### PR DESCRIPTION
As that would mean we are putting in concrete SLF4J API and related classes for consumers of MIMA uber artifacts.

Exclude them from both uber artifact, and instead expect from integrators to provide binary compatible SLF4J API and related classes on classpath. SLF4J is great at API compatibility, hence, we should give greater freedom to integrators of MIMA.

Also, update README and detail out the changes and requirements.