### PR TITLE
HTTP proxy controls for MIMA

### DIFF
--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/CommandSupport.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/CommandSupport.java
@@ -2,6 +2,7 @@ package eu.maveniverse.maven.mima.cli;
 
 import eu.maveniverse.maven.mima.context.Context;
 import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.HTTPProxy;
 import eu.maveniverse.maven.mima.context.MavenSystemHome;
 import eu.maveniverse.maven.mima.context.MavenUserHome;
 import eu.maveniverse.maven.mima.context.Runtime;
@@ -106,6 +107,14 @@ public abstract class CommandSupport implements Callable<Integer> {
                     logger.info("                          {}", mirrored);
                 }
             }
+        }
+
+        if (context.httpProxy() != null) {
+            HTTPProxy proxy = context.httpProxy();
+            logger.info("");
+            logger.info("             HTTP PROXY");
+            logger.info("                    url {}://{}:{}", proxy.getProtocol(), proxy.getHost(), proxy.getPort());
+            logger.info("          nonProxyHosts {}", proxy.getNonProxyHosts());
         }
 
         if (verbose) {

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/Context.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/Context.java
@@ -44,6 +44,8 @@ public final class Context implements Closeable {
 
     private final List<RemoteRepository> remoteRepositories;
 
+    private final HTTPProxy httpProxy;
+
     private final Runnable managedCloser;
 
     public Context(
@@ -55,6 +57,7 @@ public final class Context implements Closeable {
             RepositorySystem repositorySystem,
             RepositorySystemSession repositorySystemSession,
             List<RemoteRepository> remoteRepositories,
+            HTTPProxy httpProxy,
             Runnable managedCloser) {
         this.runtime = requireNonNull(runtime);
         this.contextOverrides = requireNonNull(contextOverrides);
@@ -64,6 +67,7 @@ public final class Context implements Closeable {
         this.repositorySystemSession = requireNonNull(repositorySystemSession);
         this.repositorySystem = requireNonNull(repositorySystem);
         this.remoteRepositories = requireNonNull(remoteRepositories);
+        this.httpProxy = httpProxy;
         this.managedCloser = managedCloser;
     }
 
@@ -123,6 +127,16 @@ public final class Context implements Closeable {
      */
     public List<RemoteRepository> remoteRepositories() {
         return remoteRepositories;
+    }
+
+    /**
+     * Returns HTTP Proxy that Resolver will use, or {@code null}. This configuration may come from user
+     * {@code settings.xml}.
+     *
+     * @since 2.4.0
+     */
+    public HTTPProxy httpProxy() {
+        return httpProxy;
     }
 
     /**

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/HTTPProxy.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/HTTPProxy.java
@@ -1,0 +1,69 @@
+package eu.maveniverse.maven.mima.context;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Registry of known {@link Runtime} instances. It orders them by priority. This class is the "entry point" in MIMA to
+ * obtain actual {@link Runtime} instance.
+ *
+ * @since 2.4.0
+ */
+public final class HTTPProxy {
+    private final String protocol;
+
+    private final String host;
+
+    private final int port;
+
+    private final String nonProxyHosts;
+
+    private final Map<String, Object> data;
+
+    public HTTPProxy(String protocol, String host, int port, String nonProxyHosts, Map<String, Object> data) {
+        this.protocol = requireNonNull(protocol);
+        this.host = requireNonNull(host);
+        this.port = port;
+        this.nonProxyHosts = nonProxyHosts != null ? nonProxyHosts : "";
+        this.data = data != null ? Collections.unmodifiableMap(data) : Collections.emptyMap();
+    }
+
+    /**
+     * The protocol to use with HTTP Proxy, never {@code null}.
+     */
+    public String getProtocol() {
+        return protocol;
+    }
+
+    /**
+     * The HTTP Proxy hostname, never {@code null}.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * The HTTP Proxy port.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * The comma or pipe delimited list of non-proxy hosts, never {@code null}.
+     *
+     * @see <a href="https://maven.apache.org/settings.html#proxies">Maven Settings Reference - Proxies</a>
+     */
+    public String getNonProxyHosts() {
+        return nonProxyHosts;
+    }
+
+    /**
+     * Extra "data", like auth, never {@code null}.
+     */
+    public Map<String, Object> getData() {
+        return data;
+    }
+}

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/HTTPProxy.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/HTTPProxy.java
@@ -6,8 +6,7 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * Registry of known {@link Runtime} instances. It orders them by priority. This class is the "entry point" in MIMA to
- * obtain actual {@link Runtime} instance.
+ * HTTP Proxy configuration, that resolver uses.
  *
  * @since 2.4.0
  */
@@ -52,7 +51,7 @@ public final class HTTPProxy {
     }
 
     /**
-     * The comma or pipe delimited list of non-proxy hosts, never {@code null}.
+     * String of comma or pipe delimited list of non-proxy hosts, never {@code null}.
      *
      * @see <a href="https://maven.apache.org/settings.html#proxies">Maven Settings Reference - Proxies</a>
      */

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupport.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupport.java
@@ -124,6 +124,7 @@ public abstract class RuntimeSupport implements Runtime {
                 context.repositorySystem(),
                 session,
                 context.repositorySystem().newResolutionRepositories(session, remoteRepositories),
+                context.httpProxy(),
                 null); // derived context: close should NOT shut down repositorySystem
     }
 

--- a/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
+++ b/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
@@ -289,6 +289,7 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
             for (Proxy proxy : settings.getProxies()) {
                 proxy.setActive(false);
             }
+            settings.flushActiveProxy();
         }
         new MavenSettingsMerger().merge(settings, mixin, TrackableBase.GLOBAL_LEVEL);
     }

--- a/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
+++ b/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 
 import eu.maveniverse.maven.mima.context.Context;
 import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.HTTPProxy;
 import eu.maveniverse.maven.mima.context.MavenSystemHome;
 import eu.maveniverse.maven.mima.context.MavenUserHome;
 import eu.maveniverse.maven.mima.context.internal.MavenSystemHomeImpl;
@@ -143,6 +144,13 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
                         Paths.get(settings.getLocalRepository()).toAbsolutePath());
             }
 
+            // settings: active proxy
+            Proxy proxy = settings.getActiveProxy();
+            HTTPProxy httpProxy = null;
+            if (proxy != null) {
+                httpProxy = toHTTPProxy(proxy);
+            }
+
             // settings: active profiles
             List<Profile> activeProfiles =
                     activeProfilesByActivation(alteredOverrides, baseDir, settings, profileSelector);
@@ -220,10 +228,22 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
                     repositorySystem,
                     session,
                     repositorySystem.newResolutionRepositories(session, new ArrayList<>(remoteRepositories.values())),
+                    httpProxy,
                     managedCloser);
         } catch (Exception e) {
             throw new IllegalStateException("Cannot create context from scratch", e);
         }
+    }
+
+    private HTTPProxy toHTTPProxy(Proxy proxy) {
+        HashMap<String, Object> data = new HashMap<>();
+        if (proxy.getUsername() != null) {
+            data.put("username", proxy.getUsername());
+        }
+        if (proxy.getPassword() != null) {
+            data.put("password", proxy.getPassword());
+        }
+        return new HTTPProxy(proxy.getProtocol(), proxy.getHost(), proxy.getPort(), proxy.getNonProxyHosts(), data);
     }
 
     protected Settings newEffectiveSettings(
@@ -235,7 +255,7 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
         if (!overrides.isWithUserSettings()) {
             return new Settings();
         }
-        if (overrides.getEffectiveSettings() != null) {
+        if (overrides.getEffectiveSettings() instanceof Settings) {
             return (Settings) overrides.getEffectiveSettings();
         }
         DefaultSettingsBuildingRequest settingsBuilderRequest = new DefaultSettingsBuildingRequest();
@@ -252,11 +272,25 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
         }
         settingsBuilderRequest.setUserSettingsFile(mavenUserHome.settingsXml().toFile());
         Settings result = settingsBuilder.build(settingsBuilderRequest).getEffectiveSettings();
-        if (overrides.getEffectiveSettingsMixin() != null) {
-            new MavenSettingsMerger()
-                    .merge(result, (Settings) overrides.getEffectiveSettingsMixin(), TrackableBase.GLOBAL_LEVEL);
+        if (overrides.getEffectiveSettingsMixin() instanceof Settings) {
+            settingsMixin(result, (Settings) overrides.getEffectiveSettingsMixin());
         }
         return result;
+    }
+
+    protected void settingsMixin(Settings settings, Settings mixin) {
+        // Special care for mixin that is about to add Proxy:
+        // - disable all other proxies, if exists
+        // Hence:
+        // - if mixin proxy is active, it prevails
+        // - if mixin proxy is inactive, shuts down proxy
+        boolean mixinAddsProxy = !mixin.getProxies().isEmpty();
+        if (mixinAddsProxy) {
+            for (Proxy proxy : settings.getProxies()) {
+                proxy.setActive(false);
+            }
+        }
+        new MavenSettingsMerger().merge(settings, mixin, TrackableBase.GLOBAL_LEVEL);
     }
 
     protected List<Profile> activeProfilesByActivation(


### PR DESCRIPTION
Changes:
* context exposes HTTPProxy that resolver is configured to use, so integrating app can observe it
* if settings mixin set by integrating app is about to add Proxy, disable all other existing proxies
* This way: if mixin adds active proxy, it prevails, otherwise it inhibits proxy use in resolver

Implementation note: context module is "maven free" (and should stay like it), so this PR contains one "ugly" copy pasta of Maven Settings Proxy model conversion to context's HTTPProxy class. This is unfortunate, as Maven Runtime and "standalone runtimes" does not share common ancestor that has access to Maven model (they both share context, that is maven free).

Fixes #41.
Fixes #40.