### PR TITLE
Add REPL console to mima

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -29,6 +29,14 @@
       <groupId>eu.maveniverse.maven.mima</groupId>
       <artifactId>context</artifactId>
     </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli-shell-jline3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+    </dependency>
 
     <!-- Provided (by runtime) -->
     <dependency>

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Main.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Main.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
         name = "mima",
-        subcommands = {Classpath.class, Deploy.class, Install.class, Resolve.class},
+        subcommands = {Classpath.class, Deploy.class, Install.class, Repl.class, Resolve.class},
         version = "1.0",
         description = "MIMA CLI")
 public class Main extends CommandSupport {

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Repl.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Repl.java
@@ -1,0 +1,88 @@
+package eu.maveniverse.maven.mima.cli;
+
+import eu.maveniverse.maven.mima.context.Context;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.jline.builtins.ConfigurationPath;
+import org.jline.console.SystemRegistry;
+import org.jline.console.impl.Builtins;
+import org.jline.console.impl.SystemRegistryImpl;
+import org.jline.keymap.KeyMap;
+import org.jline.reader.Binding;
+import org.jline.reader.EndOfFileException;
+import org.jline.reader.LineReader;
+import org.jline.reader.LineReaderBuilder;
+import org.jline.reader.MaskingCallback;
+import org.jline.reader.Parser;
+import org.jline.reader.Reference;
+import org.jline.reader.UserInterruptException;
+import org.jline.reader.impl.DefaultParser;
+import org.jline.terminal.Terminal;
+import org.jline.terminal.TerminalBuilder;
+import org.jline.terminal.impl.jansi.JansiTerminalProvider;
+import org.jline.widget.TailTipWidgets;
+import picocli.CommandLine;
+import picocli.shell.jline3.PicocliCommands;
+
+@CommandLine.Command(name = "repl", description = "REPL console")
+public class Repl extends CommandSupport {
+    @Override
+    protected Integer doCall(Context context) {
+        Class<?> tp = JansiTerminalProvider.class;
+
+        // set up JLine built-in commands
+        ConfigurationPath configPath = new ConfigurationPath(Paths.get("."), Paths.get("."));
+        Builtins builtins = new Builtins(Repl::workDir, configPath, null);
+        builtins.rename(org.jline.console.impl.Builtins.Command.TTOP, "top");
+        builtins.alias("zle", "widget");
+        builtins.alias("bindkey", "keymap");
+        // set up picocli commands
+        CommandLine cmd = new CommandLine(new Main());
+        PicocliCommands picocliCommands = new PicocliCommands(cmd);
+
+        Parser parser = new DefaultParser();
+
+        try (Terminal terminal = TerminalBuilder.builder().name("mima").build()) {
+            SystemRegistry systemRegistry = new SystemRegistryImpl(parser, terminal, Repl::workDir, configPath);
+            systemRegistry.setCommandRegistries(builtins, picocliCommands);
+
+            LineReader reader = LineReaderBuilder.builder()
+                    .terminal(terminal)
+                    .completer(systemRegistry.completer())
+                    .parser(parser)
+                    .variable(LineReader.LIST_MAX, 50) // max tab completion candidates
+                    .build();
+            builtins.setLineReader(reader);
+            new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TailTipWidgets.TipType.COMPLETER);
+            KeyMap<Binding> keyMap = reader.getKeyMaps().get("main");
+            keyMap.bind(new Reference("tailtip-toggle"), KeyMap.alt("s"));
+
+            String prompt = "prompt> ";
+            String rightPrompt = null;
+
+            // start the shell and process input until the user quits with Ctrl-D
+            String line;
+            while (true) {
+                try {
+                    systemRegistry.cleanUp();
+                    line = reader.readLine(prompt, rightPrompt, (MaskingCallback) null, null);
+                    systemRegistry.execute(line);
+                } catch (UserInterruptException e) {
+                    // Ignore
+                } catch (EndOfFileException e) {
+                    return 0;
+                } catch (Exception e) {
+                    systemRegistry.trace(e);
+                    return 2;
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return 1;
+        }
+    }
+
+    private static Path workDir() {
+        return Paths.get(System.getProperty("user.dir"));
+    }
+}

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Repl.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Repl.java
@@ -17,6 +17,7 @@ import org.jline.reader.Parser;
 import org.jline.reader.Reference;
 import org.jline.reader.UserInterruptException;
 import org.jline.reader.impl.DefaultParser;
+import org.jline.reader.impl.history.DefaultHistory;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.terminal.impl.jansi.JansiTerminalProvider;
@@ -46,11 +47,14 @@ public class Repl extends CommandSupport {
             SystemRegistry systemRegistry = new SystemRegistryImpl(parser, terminal, Repl::workDir, configPath);
             systemRegistry.setCommandRegistries(builtins, picocliCommands);
 
+            Path history = Paths.get(System.getProperty("user.home"), ".m2/.mima_history");
             LineReader reader = LineReaderBuilder.builder()
                     .terminal(terminal)
+                    .history(new DefaultHistory())
                     .completer(systemRegistry.completer())
                     .parser(parser)
                     .variable(LineReader.LIST_MAX, 50) // max tab completion candidates
+                    .variable(LineReader.HISTORY_FILE, history)
                     .build();
             builtins.setLineReader(reader);
             new TailTipWidgets(reader, systemRegistry::commandDescription, 5, TailTipWidgets.TipType.COMPLETER);

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,16 @@
         <artifactId>picocli-codegen</artifactId>
         <version>${version.picocli}</version>
       </dependency>
+      <dependency>
+        <groupId>info.picocli</groupId>
+        <artifactId>picocli-shell-jline3</artifactId>
+        <version>${version.picocli}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.fusesource.jansi</groupId>
+        <artifactId>jansi</artifactId>
+        <version>2.4.1</version>
+      </dependency>
 
       <dependency>
         <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Fixes #44 

Small REPL console:
```
➜  mima git:(repl) java -jar cli/target/cli-2.3.6-SNAPSHOT-uber.jar repl
[INFO] MIMA (Runtime 'standalone-static' version 2.3.6-SNAPSHOT)
[INFO] ====
prompt> help
  System:
    exit        exit from app/script
    help        command help
  Builtins:
    colors      view 256-color table and ANSI-styles
    highlighter manage nanorc theme system
    history     list history of commands
    keymap      manipulate keymaps
    less        file pager
    nano        edit files
    setopt      set options
    setvar      set lineReader variable value
    top         display and update sorted information about threads
    unsetopt    unset options
    widget      manipulate widgets
  PicocliCommands:
    classpath   Resolves Maven Artifact and prints out the classpath
    deploy      Deploys Maven Artifacts
    install     Installs Maven Artifacts
    repl        REPL console
    resolve     Resolves Maven Artifacts
prompt> 
```

<img width="520" alt="image" src="https://github.com/maveniverse/mima/assets/84022/9dd2c6de-b285-4465-8e90-d4030abcb02d">
