### PR TITLE
Update parent, plugins, Maven

### DIFF
--- a/demo/library-maven-plugin/pom.xml
+++ b/demo/library-maven-plugin/pom.xml
@@ -13,8 +13,8 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <properties>
-    <version.maven>3.9.5</version.maven>
-    <version.maven-plugin-plugin>3.9.0</version.maven-plugin-plugin>
+    <version.maven>3.9.6</version.maven>
+    <version.maven-plugin-plugin>3.10.2</version.maven-plugin-plugin>
   </properties>
 
   <dependencies>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -111,7 +111,7 @@
         <!-- 2.30.0 to keep Java 8 -->
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.40.0</version>
+        <version>2.41.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>eu.maveniverse.maven.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>6</version>
+    <version>7</version>
   </parent>
 
   <groupId>eu.maveniverse.maven.mima</groupId>
@@ -58,7 +58,7 @@
 
     <!-- Dependency versions -->
     <version.resolver>1.9.18</version.resolver>
-    <version.maven>3.9.5</version.maven>
+    <version.maven>3.9.6</version.maven>
     <version.mase>1.0.0</version.mase>
     <version.sisu>0.9.0.M2</version.sisu>
     <version.slf4j>1.7.36</version.slf4j>


### PR DESCRIPTION
Updates parent to latest, and lifts Maven to latest 3.9.6 release... not that it matters for MIMA, but now again resolver and maven versions are aligned and same as in Maven 3.9.6 distro.