### PR TITLE
add jbang catalog so you can do jbang mima@maveniverse/mima

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,10 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "mima": {
+      "script-ref": "eu.maveniverse.maven.mima:cli:RELEASE",
+      "java-agents": []
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
the cli is nice - lets make it easy to get to :) 

this PR adds jbang-catalog.json in mima repo but would be better if maveniverse/jbang-catalog repo was created then we could just do `jbang mima@maveniverse`