### PR TITLE
CLI improvements

### DIFF
--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Classpath.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Classpath.java
@@ -24,8 +24,6 @@ public final class Classpath extends ResolverCommandSupport {
 
     @Override
     protected Integer doCall(Context context) throws DependencyResolutionException {
-        info("Classpath {}", gav);
-
         Artifact artifact = new DefaultArtifact(gav);
 
         CollectRequest collectRequest = new CollectRequest();
@@ -39,7 +37,6 @@ public final class Classpath extends ResolverCommandSupport {
 
         PreorderNodeListGenerator nlg = new PreorderNodeListGenerator();
         dependencyResult.getRoot().accept(nlg);
-        info("");
         info("{}", nlg.getClassPath());
         return 0;
     }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/CommandSupport.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/CommandSupport.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
@@ -66,15 +65,6 @@ public abstract class CommandSupport implements Callable<Integer> {
 
     private static final ConcurrentHashMap<String, ArrayDeque<Object>> EXECUTION_CONTEXT = new ConcurrentHashMap<>();
 
-    private static final AtomicBoolean VWO = new AtomicBoolean(false);
-
-    protected void writeVersionOnce(Runtime runtime) {
-        if (VWO.compareAndSet(false, true)) {
-            info("MIMA (Runtime '{}' version {})", runtime.name(), runtime.version());
-            info("====");
-        }
-    }
-
     protected Object getOrCreate(String key, Supplier<?> supplier) {
         ArrayDeque<Object> deque = EXECUTION_CONTEXT.computeIfAbsent(key, k -> new ArrayDeque<>());
         if (deque.isEmpty()) {
@@ -105,7 +95,8 @@ public abstract class CommandSupport implements Callable<Integer> {
     }
 
     protected void mayDumpEnv(Runtime runtime, Context context, boolean verbose) {
-        writeVersionOnce(runtime);
+        info("MIMA (Runtime '{}' version {})", runtime.name(), runtime.version());
+        info("====");
         info("          Maven version {}", runtime.mavenVersion());
         info("                Managed {}", runtime.managedRepositorySystem());
         info("                Basedir {}", context.basedir());

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/CommandSupport.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/CommandSupport.java
@@ -104,7 +104,7 @@ public abstract class CommandSupport implements Callable<Integer> {
         return deque.peek();
     }
 
-    protected void mayDumpEnv(Runtime runtime, Context context) {
+    protected void mayDumpEnv(Runtime runtime, Context context, boolean verbose) {
         writeVersionOnce(runtime);
         info("          Maven version {}", runtime.mavenVersion());
         info("                Managed {}", runtime.managedRepositorySystem());
@@ -171,9 +171,7 @@ public abstract class CommandSupport implements Callable<Integer> {
     }
 
     protected Runtime getRuntime() {
-        Runtime runtime = (Runtime) getOrCreate(Runtime.class.getName(), Runtimes.INSTANCE::getRuntime);
-        writeVersionOnce(runtime);
-        return runtime;
+        return (Runtime) getOrCreate(Runtime.class.getName(), Runtimes.INSTANCE::getRuntime);
     }
 
     protected ContextOverrides getContextOverrides() {

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Deploy.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Deploy.java
@@ -30,8 +30,6 @@ public final class Deploy extends ResolverCommandSupport {
 
     @Override
     protected Integer doCall(Context context) throws DeploymentException {
-        info("Deploying {}", gav);
-
         Artifact jarArtifact = new DefaultArtifact(gav);
         jarArtifact = jarArtifact.setFile(jar.toFile());
 
@@ -48,7 +46,6 @@ public final class Deploy extends ResolverCommandSupport {
 
         context.repositorySystem().deploy(getRepositorySystemSession(), deployRequest);
 
-        info("");
         info("Deployed {}", gav);
         return 0;
     }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Dump.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Dump.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
 public final class Dump extends CommandSupport {
     @Override
     public Integer call() {
-        mayDumpEnv(getRuntime(), getContext());
+        mayDumpEnv(getRuntime(), getContext(), true);
         return 0;
     }
 }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Exists.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Exists.java
@@ -44,9 +44,6 @@ public final class Exists extends SearchCommandSupport {
 
     @Override
     protected Integer doCall() throws IOException {
-        info("Exists {}", gavs);
-        info("");
-
         ArrayList<Artifact> missingOnes = new ArrayList<>();
         ArrayList<Artifact> existingOnes = new ArrayList<>();
         try (SearchBackend backend = getRemoteRepositoryBackend(repositoryId, repositoryBaseUri, repositoryVendor)) {

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Graph.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Graph.java
@@ -53,8 +53,6 @@ public final class Graph extends ResolverCommandSupport {
 
     @Override
     protected Integer doCall(Context context) throws DependencyCollectionException {
-        info("Collecting {}", gav);
-
         DefaultRepositorySystemSession session = new DefaultRepositorySystemSession(context.repositorySystemSession());
         session.setConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, ConflictResolver.Verbosity.FULL);
         session.setConfigProperty(DependencyManagerUtils.CONFIG_PROP_VERBOSE, true);
@@ -79,7 +77,6 @@ public final class Graph extends ResolverCommandSupport {
         collectRequest.setRoot(new Dependency(artifact, ""));
         collectRequest.setRepositories(context.remoteRepositories());
 
-        info("");
         context.repositorySystem()
                 .collectDependencies(session, collectRequest)
                 .getRoot()

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Identify.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Identify.java
@@ -3,7 +3,6 @@ package eu.maveniverse.maven.mima.cli;
 import static org.apache.maven.search.api.request.FieldQuery.fieldQuery;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.maven.search.api.MAVEN;
 import org.apache.maven.search.api.SearchBackend;
 import org.apache.maven.search.api.SearchRequest;
@@ -21,18 +20,15 @@ public final class Identify extends SearchCommandSupport {
 
     @Override
     protected Integer doCall() throws IOException {
-        info("Identify {}", sha1);
-
         try (SearchBackend backend = getSmoBackend(repositoryId)) {
             SearchRequest searchRequest = new SearchRequest(fieldQuery(MAVEN.SHA1, sha1));
             SearchResponse searchResponse = backend.search(searchRequest);
-            info("");
-            AtomicInteger counter = new AtomicInteger();
-            renderPage(counter, searchResponse.getPage()).forEach(this::info);
+
+            renderPage(searchResponse.getPage()).forEach(this::info);
             while (searchResponse.getCurrentHits() > 0) {
                 searchResponse =
                         backend.search(searchResponse.getSearchRequest().nextPage());
-                renderPage(counter, searchResponse.getPage()).forEach(this::info);
+                renderPage(searchResponse.getPage()).forEach(this::info);
             }
         }
         return 0;

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Install.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Install.java
@@ -26,8 +26,6 @@ public final class Install extends ResolverCommandSupport {
 
     @Override
     protected Integer doCall(Context context) throws InstallationException {
-        info("Installing {}", gav);
-
         Artifact jarArtifact = new DefaultArtifact(gav);
         jarArtifact = jarArtifact.setFile(jar.toFile());
 

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/List.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/List.java
@@ -4,7 +4,6 @@ import static org.apache.maven.search.api.request.BooleanQuery.and;
 import static org.apache.maven.search.api.request.FieldQuery.fieldQuery;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.maven.search.api.MAVEN;
 import org.apache.maven.search.api.SearchBackend;
 import org.apache.maven.search.api.SearchRequest;
@@ -23,8 +22,6 @@ public final class List extends SearchCommandSupport {
 
     @Override
     protected Integer doCall() throws IOException {
-        info("List {}", gavoid);
-
         try (SearchBackend backend = getRemoteRepositoryBackend(repositoryId, repositoryBaseUri, repositoryVendor)) {
             String[] elements = gavoid.split(":");
             if (elements.length < 1 || elements.length > 3) {
@@ -40,9 +37,8 @@ public final class List extends SearchCommandSupport {
             }
             SearchRequest searchRequest = new SearchRequest(query);
             SearchResponse searchResponse = backend.search(searchRequest);
-            info("");
-            AtomicInteger counter = new AtomicInteger();
-            renderPage(counter, searchResponse.getPage()).forEach(this::info);
+
+            renderPage(searchResponse.getPage()).forEach(this::info);
         }
         return 0;
     }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Main.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Main.java
@@ -30,8 +30,8 @@ public class Main extends CommandSupport {
     @Override
     public Integer call() {
         try (Context context = getContext()) {
-            verbose = true;
-            mayDumpEnv(getRuntime(), context);
+            mayDumpEnv(getRuntime(), context, false);
+            new Repl().call();
         }
         return 0;
     }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Search.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Search.java
@@ -3,7 +3,6 @@ package eu.maveniverse.maven.mima.cli;
 import static org.apache.maven.search.api.request.Query.query;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.maven.search.api.SearchBackend;
 import org.apache.maven.search.api.SearchRequest;
 import org.apache.maven.search.api.SearchResponse;
@@ -22,8 +21,6 @@ public final class Search extends SearchCommandSupport {
 
     @Override
     protected Integer doCall() throws IOException {
-        info("Search {}", expression);
-
         try (SearchBackend backend = getSmoBackend(repositoryId)) {
             Query query;
             try {
@@ -33,13 +30,12 @@ public final class Search extends SearchCommandSupport {
             }
             SearchRequest searchRequest = new SearchRequest(query);
             SearchResponse searchResponse = backend.search(searchRequest);
-            info("");
-            AtomicInteger counter = new AtomicInteger();
-            renderPage(counter, searchResponse.getPage()).forEach(this::info);
+
+            renderPage(searchResponse.getPage()).forEach(this::info);
             while (searchResponse.getCurrentHits() > 0) {
                 searchResponse =
                         backend.search(searchResponse.getSearchRequest().nextPage());
-                renderPage(counter, searchResponse.getPage()).forEach(this::info);
+                renderPage(searchResponse.getPage()).forEach(this::info);
             }
         }
         return 0;

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/SearchCommandSupport.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/SearchCommandSupport.java
@@ -6,7 +6,6 @@ import static org.apache.maven.search.api.request.FieldQuery.fieldQuery;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.maven.search.api.MAVEN;
 import org.apache.maven.search.api.Record;
 import org.apache.maven.search.api.SearchBackend;
@@ -125,7 +124,7 @@ public abstract class SearchCommandSupport extends CommandSupport {
         return result;
     }
 
-    protected java.util.List<String> renderPage(AtomicInteger counter, java.util.List<Record> page) {
+    protected java.util.List<String> renderPage(java.util.List<Record> page) {
         ArrayList<String> result = new ArrayList<>();
         for (Record record : page) {
             StringBuilder sb = new StringBuilder();
@@ -162,7 +161,7 @@ public abstract class SearchCommandSupport extends CommandSupport {
                 remarks.add("hasJavadoc=" + record.getValue(MAVEN.HAS_JAVADOC));
             }
 
-            result.add(counter.incrementAndGet() + ". " + sb);
+            result.add("- " + sb);
             if (!remarks.isEmpty()) {
                 result.add("   " + remarks);
             }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/SearchCommandSupport.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/SearchCommandSupport.java
@@ -162,7 +162,7 @@ public abstract class SearchCommandSupport extends CommandSupport {
             }
 
             result.add("" + sb);
-            if (!remarks.isEmpty()) {
+            if (verbose && !remarks.isEmpty()) {
                 result.add("   " + remarks);
             }
         }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/SearchCommandSupport.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/SearchCommandSupport.java
@@ -161,7 +161,7 @@ public abstract class SearchCommandSupport extends CommandSupport {
                 remarks.add("hasJavadoc=" + record.getValue(MAVEN.HAS_JAVADOC));
             }
 
-            result.add("- " + sb);
+            result.add("" + sb);
             if (!remarks.isEmpty()) {
                 result.add("   " + remarks);
             }

--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Verify.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Verify.java
@@ -27,12 +27,10 @@ public final class Verify extends SearchCommandSupport {
 
     @Override
     protected Integer doCall() throws IOException {
-        info("Verify {}", gav);
-
         try (SearchBackend backend = getRemoteRepositoryBackend(repositoryId, repositoryBaseUri, repositoryVendor)) {
             Artifact artifact = new DefaultArtifact(gav);
             boolean verified = verify(backend, new DefaultArtifact(gav), sha1);
-            info("");
+
             info("Artifact SHA1({})={}: {}", artifact, sha1, verified ? "MATCHED" : "NOT MATCHED");
             return verified ? 0 : 1;
         }

--- a/cli/src/main/resources/simplelogger.properties
+++ b/cli/src/main/resources/simplelogger.properties
@@ -4,5 +4,5 @@ org.slf4j.simpleLogger.showThreadName=false
 org.slf4j.simpleLogger.showLogName=false
 org.slf4j.simpleLogger.logFile=System.out
 org.slf4j.simpleLogger.cacheOutputStream=true
-org.slf4j.simpleLogger.levelInBrackets=true
+org.slf4j.simpleLogger.levelInBrackets=false
 org.slf4j.simpleLogger.warnLevelString=WARNING


### PR DESCRIPTION
Fixes #74

Changes:
* default cmd is now REPL, and it dumps just minimal headers (not 3 pages of properties), to see all invoke `dump -v` in REPL
* when directly command invoked (like `list` or `classpath` it executes and CLI exits)
* removed all the redundant outputs, numberings
* hence, direct invocations produce merely needed output (scriptable)
* removed INFO prefix