### PR TITLE
add help and version commands

### DIFF
--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Main.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Main.java
@@ -25,7 +25,8 @@ import picocli.CommandLine;
             Verify.class
         },
         version = "1.0",
-        description = "MIMA CLI")
+        description = "MIMA CLI",
+        mixinStandardHelpOptions = true)
 public class Main extends CommandSupport {
     @Override
     public Integer call() {


### PR DESCRIPTION
i noticed mima help or mima -h did not exist so to get usage you currently have to be told asking for help is an error ;)

this pr is minimal fix to enable picocli to add help and version flags.