### PR TITLE
Add automatic module names

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -21,6 +21,7 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <properties>
+    <maven.compiler.release>11</maven.compiler.release>
     <mainClass>eu.maveniverse.maven.mima.cli.Main</mainClass>
     <Automatic-Module-Name>eu.maveniverse.maven.mima.cli</Automatic-Module-Name>
   </properties>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -21,8 +21,8 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
     <mainClass>eu.maveniverse.maven.mima.cli.Main</mainClass>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.cli</Automatic-Module-Name>
   </properties>
 
   <dependencies>

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -20,6 +20,10 @@
   <artifactId>context</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
 
+  <properties>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.context</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -21,7 +21,6 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
     <Automatic-Module-Name>eu.maveniverse.maven.mima.context</Automatic-Module-Name>
   </properties>
 

--- a/context/pom.xml
+++ b/context/pom.xml
@@ -21,6 +21,7 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <properties>
+    <maven.compiler.release>11</maven.compiler.release>
     <Automatic-Module-Name>eu.maveniverse.maven.mima.context</Automatic-Module-Name>
   </properties>
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -47,9 +47,10 @@
     <requireBuildtimeMavenVersion.version>[3.6.3,)</requireBuildtimeMavenVersion.version>
     <requireBuildtimeJavaVersion.version>[8,)</requireBuildtimeJavaVersion.version>
 
-    <!-- Demo is Java 8 -->
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+    <!-- Demo is Java 11 -->
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <!--
     Test defaults.
     -->

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -47,10 +47,9 @@
     <requireBuildtimeMavenVersion.version>[3.6.3,)</requireBuildtimeMavenVersion.version>
     <requireBuildtimeJavaVersion.version>[8,)</requireBuildtimeJavaVersion.version>
 
-    <!-- Demo is Java 11 -->
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.release>11</maven.compiler.release>
+    <!-- Demo is Java 8+ -->
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <!--
     Test defaults.
     -->

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,8 @@
 
   <properties>
     <project.build.outputTimestamp>2024-05-26T20:22:04Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-01-20T16:29:03Z</project.build.outputTimestamp>
+    <maven.compiler.release>11</maven.compiler.release>
 
     <!--
     Build time: latest Maven and LTS Java.
@@ -293,6 +295,17 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${Automatic-Module-Name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
 
   <properties>
     <project.build.outputTimestamp>2024-05-26T20:22:04Z</project.build.outputTimestamp>
-    <project.build.outputTimestamp>2024-01-20T16:29:03Z</project.build.outputTimestamp>
 
     <!--
     Build time: latest Maven and LTS Java.

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
   <properties>
     <project.build.outputTimestamp>2024-05-26T20:22:04Z</project.build.outputTimestamp>
     <project.build.outputTimestamp>2024-01-20T16:29:03Z</project.build.outputTimestamp>
-    <maven.compiler.release>11</maven.compiler.release>
 
     <!--
     Build time: latest Maven and LTS Java.

--- a/runtime/embedded-maven/pom.xml
+++ b/runtime/embedded-maven/pom.xml
@@ -20,6 +20,10 @@
   <artifactId>embedded-maven</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
 
+  <properties>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.runtime.maven</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>eu.maveniverse.maven.mima</groupId>

--- a/runtime/standalone-shared/pom.xml
+++ b/runtime/standalone-shared/pom.xml
@@ -20,6 +20,10 @@
   <artifactId>standalone-shared</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
 
+  <properties>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.runtime.shared</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>eu.maveniverse.maven.mima</groupId>

--- a/runtime/standalone-sisu-uber/pom.xml
+++ b/runtime/standalone-sisu-uber/pom.xml
@@ -21,7 +21,11 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <!-- Note: this plugin has no sources, is just shaded :standalone-sisu, 
-  still Central requires presence of soueces/javadocs JARs, so they are faked. -->
+  still Central requires presence of sources/javadocs JARs, so they are faked. -->
+
+  <properties>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.runtime.standalonesisu</Automatic-Module-Name>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/runtime/standalone-sisu/pom.xml
+++ b/runtime/standalone-sisu/pom.xml
@@ -20,6 +20,10 @@
   <artifactId>standalone-sisu</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
 
+  <properties>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.runtime.standalonesisu</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>eu.maveniverse.maven.mima</groupId>

--- a/runtime/standalone-static-uber/pom.xml
+++ b/runtime/standalone-static-uber/pom.xml
@@ -21,7 +21,11 @@
   <name>${project.groupId}:${project.artifactId}</name>
 
   <!-- Note: this plugin has no sources, is just shaded :standalone-static,
-  still Central requires presence of soueces/javadocs JARs, so they are faked. -->
+  still Central requires presence of sources/javadocs JARs, so they are faked. -->
+
+  <properties>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.runtime.standalonestatic</Automatic-Module-Name>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/runtime/standalone-static/pom.xml
+++ b/runtime/standalone-static/pom.xml
@@ -20,6 +20,10 @@
   <artifactId>standalone-static</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
 
+  <properties>
+    <Automatic-Module-Name>eu.maveniverse.maven.mima.runtime.standalonestatic</Automatic-Module-Name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>eu.maveniverse.maven.mima</groupId>


### PR DESCRIPTION
Add JAR manifest header with automatic module names.

This allows now running MIMA or even MIMA CLI as module:
* put all of mima onto module path
* put all of resolver onto module path (they are also auto-modules)
* you must put Maven JARs onto classpath (due split packages)

And shoot:
`--module eu.maveniverse.maven.mima.cli/eu.maveniverse.maven.mima.cli.Main`

Fixes #71 