### PR TITLE
Add classpath command scope

### DIFF
--- a/cli/src/main/java/eu/maveniverse/maven/mima/cli/Classpath.java
+++ b/cli/src/main/java/eu/maveniverse/maven/mima/cli/Classpath.java
@@ -19,8 +19,17 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "classpath", description = "Resolves Maven Artifact and prints out the classpath")
 public final class Classpath extends ResolverCommandSupport {
 
+    enum ClasspathScope {
+        runtime,
+        compile,
+        test;
+    }
+
     @CommandLine.Parameters(index = "0", description = "The GAV to print classpath for")
     private String gav;
+
+    @CommandLine.Option(names = "--scope", defaultValue = "runtime")
+    private ClasspathScope scope;
 
     @Override
     protected Integer doCall(Context context) throws DependencyResolutionException {
@@ -30,7 +39,7 @@ public final class Classpath extends ResolverCommandSupport {
         collectRequest.setRoot(new Dependency(artifact, JavaScopes.COMPILE));
         collectRequest.setRepositories(context.remoteRepositories());
         DependencyRequest dependencyRequest =
-                new DependencyRequest(collectRequest, DependencyFilterUtils.classpathFilter(JavaScopes.COMPILE));
+                new DependencyRequest(collectRequest, DependencyFilterUtils.classpathFilter(scope.name()));
 
         verbose("Resolving {}", dependencyRequest);
         DependencyResult dependencyResult =


### PR DESCRIPTION
As currently it produces _compile_ scope, that is not runtime, hence may be unexpected.

Now there is `--scope` option that accepts values `runtime` (default), `compile` (as now) and `test` that prints runtime, compile and test classpaths correspondingly.

Fixes #88 