### PR TITLE
Introduce lookup

### DIFF
--- a/context/src/main/java/eu/maveniverse/maven/mima/context/Context.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/Context.java
@@ -56,6 +56,8 @@ public final class Context implements Closeable {
 
     private final HTTPProxy httpProxy;
 
+    private final Lookup lookup;
+
     private final Runnable managedCloser;
 
     public Context(
@@ -68,6 +70,7 @@ public final class Context implements Closeable {
             RepositorySystemSession repositorySystemSession,
             List<RemoteRepository> remoteRepositories,
             HTTPProxy httpProxy,
+            Lookup lookup,
             Runnable managedCloser) {
         this.closed = new AtomicBoolean(false);
         this.runtime = requireNonNull(runtime);
@@ -79,6 +82,7 @@ public final class Context implements Closeable {
         this.repositorySystem = requireNonNull(repositorySystem);
         this.remoteRepositories = requireNonNull(remoteRepositories);
         this.httpProxy = httpProxy;
+        this.lookup = requireNonNull(lookup);
         this.managedCloser = managedCloser;
     }
 
@@ -148,6 +152,15 @@ public final class Context implements Closeable {
      */
     public HTTPProxy httpProxy() {
         return httpProxy;
+    }
+
+    /**
+     * Returns {@link Lookup} instance usable to look up resolver components, never {@code null}.
+     *
+     * @since TBD
+     */
+    public Lookup lookup() {
+        return lookup;
     }
 
     /**

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/Context.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/Context.java
@@ -157,7 +157,7 @@ public final class Context implements Closeable {
     /**
      * Returns {@link Lookup} instance usable to look up resolver components, never {@code null}.
      *
-     * @since TBD
+     * @since 2.4.10
      */
     public Lookup lookup() {
         return lookup;

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/Lookup.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/Lookup.java
@@ -1,6 +1,5 @@
 package eu.maveniverse.maven.mima.context;
 
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -18,9 +17,4 @@ public interface Lookup {
      * Performs lookup for component with passed in type and name, and returns it as optional, never {@code null}.
      */
     <T> Optional<T> lookup(Class<T> type, String name);
-
-    /**
-     * Returns map of components for passed in type, never {@code null}.
-     */
-    <T> Map<String, T> lookupMap(Class<T> type);
 }

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/Lookup.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/Lookup.java
@@ -1,0 +1,26 @@
+package eu.maveniverse.maven.mima.context;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A simple "lookup" that allows to lookup various components. Lookup shares lifecycle with {@link Context}.
+ *
+ * @since TBD
+ */
+public interface Lookup {
+    /**
+     * Performs lookup for component with passed in type, and returns it as optional, never {@code null}.
+     */
+    <T> Optional<T> lookup(Class<T> type);
+
+    /**
+     * Performs lookup for component with passed in type and name, and returns it as optional, never {@code null}.
+     */
+    <T> Optional<T> lookup(Class<T> type, String name);
+
+    /**
+     * Returns map of components for passed in type, never {@code null}.
+     */
+    <T> Map<String, T> lookupMap(Class<T> type);
+}

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/Lookup.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/Lookup.java
@@ -4,8 +4,12 @@ import java.util.Optional;
 
 /**
  * A simple "lookup" that allows to lookup various components. Lookup shares lifecycle with {@link Context}.
+ * <p>
+ * Note: this component offers access to Resolver internals, but it is up to caller to know really how to use
+ * this feature (for example due compatibility reasons). Ideally, you do not want to use this, or use it only
+ * in some "advanced scenarios".
  *
- * @since TBD
+ * @since 2.4.10
  */
 public interface Lookup {
     /**

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/internal/IteratingLookup.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/internal/IteratingLookup.java
@@ -1,0 +1,46 @@
+package eu.maveniverse.maven.mima.context.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.mima.context.Lookup;
+import java.util.*;
+
+/**
+ * A {@link Lookup} implementation that is able to iterate through several lookups, applying "first deliver wins"
+ * strategy.
+ *
+ * @since TBD
+ */
+public final class IteratingLookup implements Lookup {
+    private final Collection<Lookup> lookups;
+
+    public IteratingLookup(Lookup... lookups) {
+        this(Arrays.asList(lookups));
+    }
+
+    public IteratingLookup(Collection<Lookup> lookups) {
+        this.lookups = requireNonNull(lookups);
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type) {
+        for (Lookup lookup : lookups) {
+            Optional<T> result = lookup.lookup(type);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type, String name) {
+        for (Lookup lookup : lookups) {
+            Optional<T> result = lookup.lookup(type, name);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/internal/IteratingLookup.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/internal/IteratingLookup.java
@@ -9,7 +9,7 @@ import java.util.*;
  * A {@link Lookup} implementation that is able to iterate through several lookups, applying "first deliver wins"
  * strategy.
  *
- * @since TBD
+ * @since 2.4.10
  */
 public final class IteratingLookup implements Lookup {
     private final Collection<Lookup> lookups;

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupport.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupport.java
@@ -134,6 +134,7 @@ public abstract class RuntimeSupport implements Runtime {
                 session,
                 context.repositorySystem().newResolutionRepositories(session, remoteRepositories),
                 context.httpProxy(),
+                context.lookup(),
                 null); // derived context: close should NOT shut down repositorySystem
     }
 

--- a/demo/library/pom.xml
+++ b/demo/library/pom.xml
@@ -32,6 +32,18 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>1.9.18</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
+      <version>1.9.18</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
       <artifactId>maven-resolver-impl</artifactId>
       <version>1.9.18</version>
       <scope>provided</scope>

--- a/demo/library/pom.xml
+++ b/demo/library/pom.xml
@@ -30,6 +30,12 @@
       <groupId>eu.maveniverse.maven.mima</groupId>
       <artifactId>context</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <version>1.9.18</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- runtime dependency (dormant outside of Maven) -->
     <dependency>
       <groupId>eu.maveniverse.maven.mima.runtime</groupId>

--- a/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
+++ b/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
@@ -18,8 +18,13 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.impl.OfflineController;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.transfer.RepositoryOfflineException;
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +49,13 @@ public class Classpath {
 
     private String doClasspath(Context context, Artifact artifact) throws DependencyResolutionException {
         logger.info("doClasspath: {}", context.remoteRepositories());
+
+        RemoteRepositoryManager remoteRepositoryManager = context.lookup().lookup(RemoteRepositoryManager.class).orElseThrow(() -> new IllegalStateException("offline controller not found"));
+        for (RemoteRepository repository : context.remoteRepositories()) {
+            RepositoryPolicy policy = remoteRepositoryManager.getPolicy(context.repositorySystemSession(), repository, !artifact.isSnapshot(), artifact.isSnapshot());
+            logger.info("Repository {} effective policy: {}", repository.getId(), policy);
+        }
+
         Dependency dependency = new Dependency(artifact, "runtime");
         CollectRequest collectRequest = new CollectRequest();
         collectRequest.setRoot(dependency);

--- a/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
+++ b/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
@@ -23,7 +23,6 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
-import org.eclipse.aether.spi.io.FileProcessor;
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,10 +84,6 @@ public class Classpath {
 
         PreorderNodeListGenerator nlg = new PreorderNodeListGenerator();
         rootNode.accept(nlg);
-
-        // this is just for demo purpose here
-        FileProcessor fileProcessor = context.lookup().lookup(FileProcessor.class).orElseThrow(() -> new IllegalStateException("lookup failed"));
-
         return nlg.getClassPath();
     }
 

--- a/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
+++ b/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
@@ -23,6 +23,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
+import org.eclipse.aether.spi.io.FileProcessor;
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,16 +86,9 @@ public class Classpath {
         PreorderNodeListGenerator nlg = new PreorderNodeListGenerator();
         rootNode.accept(nlg);
 
-        // This works only in Maven 3.9.x + Resolver 1.9.x (these classes were introduced in recent resolver)
-//        ChecksumAlgorithmFactory sha1 = context.lookup().lookup(ChecksumAlgorithmFactory.class, "SHA-1").orElseThrow(() -> new IllegalStateException("component not found"));
-//        for (File file : nlg.getFiles()) {
-//            try {
-//                Map<String, String> hashes = ChecksumAlgorithmHelper.calculate(file, Collections.singletonList(sha1));
-//                logger.info("{}({})={}", sha1.getName(), file.getName(), hashes.get(sha1.getName()));
-//            } catch (IOException e) {
-//                logger.warn("IO problem while calculating sha1 of {}", file, e);
-//            }
-//        }
+        // this is just for demo purpose here
+        FileProcessor fileProcessor = context.lookup().lookup(FileProcessor.class).orElseThrow(() -> new IllegalStateException("lookup failed"));
+
         return nlg.getClassPath();
     }
 

--- a/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
+++ b/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
@@ -23,8 +23,6 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
 import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResolutionException;
-import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
-import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmHelper;
 import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,15 +90,16 @@ public class Classpath {
         PreorderNodeListGenerator nlg = new PreorderNodeListGenerator();
         rootNode.accept(nlg);
 
-        ChecksumAlgorithmFactory sha1 = context.lookup().lookup(ChecksumAlgorithmFactory.class, "SHA-1").orElseThrow(() -> new IllegalStateException("component not found"));
-        for (File file : nlg.getFiles()) {
-            try {
-                Map<String, String> hashes = ChecksumAlgorithmHelper.calculate(file, Collections.singletonList(sha1));
-                logger.info("{}({})={}", sha1.getName(), file.getName(), hashes.get(sha1.getName()));
-            } catch (IOException e) {
-                logger.warn("IO problem while calculating sha1 of {}", file, e);
-            }
-        }
+        // This works only in Maven 3.9.x + Resolver 1.9.x (these classes were introduced in recent resolver)
+//        ChecksumAlgorithmFactory sha1 = context.lookup().lookup(ChecksumAlgorithmFactory.class, "SHA-1").orElseThrow(() -> new IllegalStateException("component not found"));
+//        for (File file : nlg.getFiles()) {
+//            try {
+//                Map<String, String> hashes = ChecksumAlgorithmHelper.calculate(file, Collections.singletonList(sha1));
+//                logger.info("{}({})={}", sha1.getName(), file.getName(), hashes.get(sha1.getName()));
+//            } catch (IOException e) {
+//                logger.warn("IO problem while calculating sha1 of {}", file, e);
+//            }
+//        }
         return nlg.getClassPath();
     }
 

--- a/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
+++ b/demo/library/src/main/java/eu/maveniverse/maven/mima/impl/library/Classpath.java
@@ -27,11 +27,6 @@ import org.eclipse.aether.util.graph.visitor.PreorderNodeListGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-
 /**
  * This is an imaginary library class that wants to:
  * <ul>

--- a/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
+++ b/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
@@ -13,9 +13,7 @@ import eu.maveniverse.maven.mima.context.internal.MavenUserHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.RuntimeSupport;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -123,15 +121,6 @@ public final class MavenRuntime extends RuntimeSupport {
                                     return Optional.of(plexusContainer.lookup(type, name));
                                 } catch (ComponentLookupException e) {
                                     return Optional.empty();
-                                }
-                            }
-
-                            @Override
-                            public <T> Map<String, T> lookupMap(Class<T> type) {
-                                try {
-                                    return plexusContainer.lookupMap(type);
-                                } catch (ComponentLookupException e) {
-                                    return Collections.emptyMap();
                                 }
                             }
                         },

--- a/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
+++ b/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
@@ -7,7 +7,11 @@
  */
 package eu.maveniverse.maven.mima.runtime.maven;
 
-import eu.maveniverse.maven.mima.context.*;
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.HTTPProxy;
+import eu.maveniverse.maven.mima.context.MavenSystemHome;
+import eu.maveniverse.maven.mima.context.MavenUserHome;
 import eu.maveniverse.maven.mima.context.internal.MavenSystemHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.MavenUserHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.RuntimeSupport;

--- a/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
+++ b/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
@@ -11,10 +11,10 @@ import eu.maveniverse.maven.mima.context.*;
 import eu.maveniverse.maven.mima.context.internal.MavenSystemHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.MavenUserHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.RuntimeSupport;
+import eu.maveniverse.maven.mima.runtime.maven.internal.PlexusLookup;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -24,7 +24,6 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.rtinfo.RuntimeInformation;
 import org.apache.maven.settings.Proxy;
 import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 
@@ -105,25 +104,7 @@ public final class MavenRuntime extends RuntimeSupport {
                         session,
                         repositorySystem.newResolutionRepositories(session, effective.getRepositories()),
                         toHTTPProxy(mavenSession.getSettings().getActiveProxy()),
-                        new Lookup() {
-                            @Override
-                            public <T> Optional<T> lookup(Class<T> type) {
-                                try {
-                                    return Optional.of(plexusContainer.lookup(type));
-                                } catch (ComponentLookupException e) {
-                                    return Optional.empty();
-                                }
-                            }
-
-                            @Override
-                            public <T> Optional<T> lookup(Class<T> type, String name) {
-                                try {
-                                    return Optional.of(plexusContainer.lookup(type, name));
-                                } catch (ComponentLookupException e) {
-                                    return Optional.empty();
-                                }
-                            }
-                        },
+                        new PlexusLookup(plexusContainer),
                         null),
                 false); // unmanaged context: close should NOT shut down repositorySystem
     }

--- a/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/internal/PlexusLookup.java
+++ b/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/internal/PlexusLookup.java
@@ -1,0 +1,34 @@
+package eu.maveniverse.maven.mima.runtime.maven.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.mima.context.Lookup;
+import java.util.Optional;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+
+public final class PlexusLookup implements Lookup {
+    private final PlexusContainer plexusContainer;
+
+    public PlexusLookup(PlexusContainer plexusContainer) {
+        this.plexusContainer = requireNonNull(plexusContainer);
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type) {
+        try {
+            return Optional.of(plexusContainer.lookup(type));
+        } catch (ComponentLookupException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type, String name) {
+        try {
+            return Optional.of(plexusContainer.lookup(type, name));
+        } catch (ComponentLookupException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
+++ b/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
@@ -9,11 +9,7 @@ package eu.maveniverse.maven.mima.runtime.shared;
 
 import static java.util.stream.Collectors.toMap;
 
-import eu.maveniverse.maven.mima.context.Context;
-import eu.maveniverse.maven.mima.context.ContextOverrides;
-import eu.maveniverse.maven.mima.context.HTTPProxy;
-import eu.maveniverse.maven.mima.context.MavenSystemHome;
-import eu.maveniverse.maven.mima.context.MavenUserHome;
+import eu.maveniverse.maven.mima.context.*;
 import eu.maveniverse.maven.mima.context.internal.MavenSystemHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.MavenUserHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.RuntimeSupport;
@@ -135,6 +131,7 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
             SettingsBuilder settingsBuilder,
             SettingsDecrypter settingsDecrypter,
             ProfileSelector profileSelector,
+            Lookup lookup,
             Runnable managedCloser) {
         try {
             ContextOverrides alteredOverrides = preBoot.getOverrides();
@@ -236,6 +233,7 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
                     session,
                     repositorySystem.newResolutionRepositories(session, new ArrayList<>(remoteRepositories.values())),
                     httpProxy,
+                    lookup,
                     managedCloser);
         } catch (Exception e) {
             throw new IllegalStateException("Cannot create context from scratch", e);

--- a/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
+++ b/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
@@ -9,7 +9,12 @@ package eu.maveniverse.maven.mima.runtime.shared;
 
 import static java.util.stream.Collectors.toMap;
 
-import eu.maveniverse.maven.mima.context.*;
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.HTTPProxy;
+import eu.maveniverse.maven.mima.context.Lookup;
+import eu.maveniverse.maven.mima.context.MavenSystemHome;
+import eu.maveniverse.maven.mima.context.MavenUserHome;
 import eu.maveniverse.maven.mima.context.internal.MavenSystemHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.MavenUserHomeImpl;
 import eu.maveniverse.maven.mima.context.internal.RuntimeSupport;

--- a/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/StandaloneSisuRuntime.java
+++ b/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/StandaloneSisuRuntime.java
@@ -12,6 +12,7 @@ import eu.maveniverse.maven.mima.context.ContextOverrides;
 import eu.maveniverse.maven.mima.runtime.shared.PreBoot;
 import eu.maveniverse.maven.mima.runtime.shared.StandaloneRuntimeSupport;
 import eu.maveniverse.maven.mima.runtime.standalonesisu.internal.SisuBooter;
+import eu.maveniverse.maven.mima.runtime.standalonesisu.internal.SisuLookup;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -19,6 +20,7 @@ import org.apache.maven.model.profile.ProfileSelector;
 import org.apache.maven.settings.building.SettingsBuilder;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.sisu.inject.MutableBeanLocator;
 
 @Singleton
 @Named
@@ -32,8 +34,10 @@ public final class StandaloneSisuRuntime extends StandaloneRuntimeSupport {
 
     private final ProfileSelector profileSelector;
 
+    private final MutableBeanLocator locator;
+
     public StandaloneSisuRuntime() {
-        this(null, null, null, null);
+        this(null, null, null, null, null);
     }
 
     @Inject
@@ -41,12 +45,14 @@ public final class StandaloneSisuRuntime extends StandaloneRuntimeSupport {
             RepositorySystem repositorySystem,
             SettingsBuilder settingsBuilder,
             SettingsDecrypter settingsDecrypter,
-            ProfileSelector profileSelector) {
+            ProfileSelector profileSelector,
+            MutableBeanLocator locator) {
         super("standalone-sisu", 30);
         this.repositorySystem = repositorySystem;
         this.settingsBuilder = settingsBuilder;
         this.settingsDecrypter = settingsDecrypter;
         this.profileSelector = profileSelector;
+        this.locator = locator;
     }
 
     @Override
@@ -67,10 +73,18 @@ public final class StandaloneSisuRuntime extends StandaloneRuntimeSupport {
                     booter.settingsBuilder,
                     booter.settingsDecrypter,
                     booter.profileSelector,
+                    new SisuLookup(booter.locator),
                     booter::close);
         } else {
             return buildContext(
-                    this, preBoot, repositorySystem, settingsBuilder, settingsDecrypter, profileSelector, null);
+                    this,
+                    preBoot,
+                    repositorySystem,
+                    settingsBuilder,
+                    settingsDecrypter,
+                    profileSelector,
+                    new SisuLookup(locator),
+                    null);
         }
     }
 }

--- a/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/internal/SisuLookup.java
+++ b/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/internal/SisuLookup.java
@@ -1,12 +1,12 @@
 package eu.maveniverse.maven.mima.runtime.standalonesisu.internal;
 
 import com.google.inject.Key;
-import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import eu.maveniverse.maven.mima.context.Lookup;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import javax.inject.Named;
 import javax.inject.Provider;
 import org.eclipse.sisu.BeanEntry;
 import org.eclipse.sisu.inject.MutableBeanLocator;
@@ -30,7 +30,7 @@ public class SisuLookup implements Lookup {
 
     @Override
     public <T> Optional<T> lookup(Class<T> type) {
-        return lookupInternal(Key.get(type, com.google.inject.name.Named.class));
+        return lookupInternal(Key.get(type, Named.class));
     }
 
     @Override

--- a/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/internal/SisuLookup.java
+++ b/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/internal/SisuLookup.java
@@ -1,0 +1,45 @@
+package eu.maveniverse.maven.mima.runtime.standalonesisu.internal;
+
+import com.google.inject.Key;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import eu.maveniverse.maven.mima.context.Lookup;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Provider;
+import org.eclipse.sisu.BeanEntry;
+import org.eclipse.sisu.inject.MutableBeanLocator;
+
+public class SisuLookup implements Lookup {
+    private final MutableBeanLocator locator;
+
+    public SisuLookup(MutableBeanLocator locator) {
+        this.locator = locator;
+    }
+
+    private <T> Optional<T> lookupInternal(Key<T> key) {
+        final Iterable<? extends BeanEntry<Named, T>> entries = locator.locate(key);
+        final Iterator<? extends BeanEntry<Named, T>> iterator = entries.iterator();
+        final Provider<T> provider = iterator.hasNext() ? iterator.next().getProvider() : null;
+        if (provider == null) {
+            return Optional.empty();
+        }
+        return Optional.of(provider.get());
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type) {
+        return lookupInternal(Key.get(type, com.google.inject.name.Named.class));
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type, String name) {
+        return lookupInternal(Key.get(type, Names.named(name)));
+    }
+
+    @Override
+    public <T> Map<String, T> lookupMap(Class<T> type) {
+        throw new RuntimeException("not implemented");
+    }
+}

--- a/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/internal/SisuLookup.java
+++ b/runtime/standalone-sisu/src/main/java/eu/maveniverse/maven/mima/runtime/standalonesisu/internal/SisuLookup.java
@@ -4,7 +4,6 @@ import com.google.inject.Key;
 import com.google.inject.name.Names;
 import eu.maveniverse.maven.mima.context.Lookup;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -36,10 +35,5 @@ public class SisuLookup implements Lookup {
     @Override
     public <T> Optional<T> lookup(Class<T> type, String name) {
         return lookupInternal(Key.get(type, Names.named(name)));
-    }
-
-    @Override
-    public <T> Map<String, T> lookupMap(Class<T> type) {
-        throw new RuntimeException("not implemented");
     }
 }

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplier.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplier.java
@@ -66,8 +66,7 @@ public class MemoizingRepositorySystemSupplier extends RepositorySystemSupplier 
         return Optional.ofNullable(lookupMap(type).get(name));
     }
 
-    @Override
-    public <T> Map<String, T> lookupMap(Class<T> type) {
+    private <T> Map<String, T> lookupMap(Class<T> type) {
         Map<String, T> result = (Map) plurals.get(type);
         if (result != null) {
             return result;

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplier.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplier.java
@@ -1,0 +1,455 @@
+package eu.maveniverse.maven.mima.runtime.standalonestatic;
+
+import eu.maveniverse.maven.mima.context.Lookup;
+import java.util.*;
+import org.apache.maven.model.building.ModelBuilder;
+import org.apache.maven.repository.internal.ModelCacheFactory;
+import org.eclipse.aether.RepositoryListener;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.*;
+import org.eclipse.aether.internal.impl.LocalPathComposer;
+import org.eclipse.aether.internal.impl.LocalPathPrefixComposerFactory;
+import org.eclipse.aether.internal.impl.TrackingFileManager;
+import org.eclipse.aether.internal.impl.collect.DependencyCollectorDelegate;
+import org.eclipse.aether.internal.impl.synccontext.named.NameMapper;
+import org.eclipse.aether.internal.impl.synccontext.named.NamedLockFactoryAdapterFactory;
+import org.eclipse.aether.named.NamedLockFactory;
+import org.eclipse.aether.spi.checksums.ProvidedChecksumsSource;
+import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactorySelector;
+import org.eclipse.aether.spi.connector.checksum.ChecksumPolicyProvider;
+import org.eclipse.aether.spi.connector.filter.RemoteRepositoryFilterSource;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutFactory;
+import org.eclipse.aether.spi.connector.layout.RepositoryLayoutProvider;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterProvider;
+import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.spi.resolution.ArtifactResolverPostProcessor;
+import org.eclipse.aether.spi.synccontext.SyncContextFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
+import org.eclipse.aether.transport.http.ChecksumExtractor;
+
+public class MemoizingRepositorySystemSupplier extends RepositorySystemSupplier implements Lookup {
+    private final HashMap<Class<?>, Object> singulars = new HashMap<>();
+
+    private final HashMap<Class<?>, Map<String, Object>> plurals = new HashMap<>();
+
+    public MemoizingRepositorySystemSupplier() {
+        memoize(RepositorySystem.class, super.get()); // to trigger filling up of memoized components
+    }
+
+    @Override
+    public RepositorySystem get() {
+        return lookup(RepositorySystem.class).orElseThrow(() -> new NoSuchElementException("No value present"));
+    }
+
+    private <T> T memoize(Class<T> key, T instance) {
+        singulars.put(key, instance);
+        return instance;
+    }
+
+    private <T> Map<String, T> memoize(Class<T> key, Map<String, T> instances) {
+        plurals.put(key, (Map) instances);
+        return instances;
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type) {
+        return lookup(type, "default");
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type, String name) {
+        return Optional.ofNullable(lookupMap(type).get(name));
+    }
+
+    @Override
+    public <T> Map<String, T> lookupMap(Class<T> type) {
+        Map<String, T> result = (Map) plurals.get(type);
+        if (result != null) {
+            return result;
+        }
+        T component = (T) singulars.get(type);
+        if (component != null) {
+            return Collections.singletonMap("default", component);
+        }
+        return Collections.emptyMap();
+    }
+
+    @Override
+    protected FileProcessor getFileProcessor() {
+        return memoize(FileProcessor.class, super.getFileProcessor());
+    }
+
+    @Override
+    protected TrackingFileManager getTrackingFileManager() {
+        return memoize(TrackingFileManager.class, super.getTrackingFileManager());
+    }
+
+    @Override
+    protected LocalPathComposer getLocalPathComposer() {
+        return memoize(LocalPathComposer.class, super.getLocalPathComposer());
+    }
+
+    @Override
+    protected LocalPathPrefixComposerFactory getLocalPathPrefixComposerFactory() {
+        return memoize(LocalPathPrefixComposerFactory.class, super.getLocalPathPrefixComposerFactory());
+    }
+
+    @Override
+    protected RepositorySystemLifecycle getRepositorySystemLifecycle() {
+        return memoize(RepositorySystemLifecycle.class, super.getRepositorySystemLifecycle());
+    }
+
+    @Override
+    protected OfflineController getOfflineController() {
+        return memoize(OfflineController.class, super.getOfflineController());
+    }
+
+    @Override
+    protected UpdatePolicyAnalyzer getUpdatePolicyAnalyzer() {
+        return memoize(UpdatePolicyAnalyzer.class, super.getUpdatePolicyAnalyzer());
+    }
+
+    @Override
+    protected ChecksumPolicyProvider getChecksumPolicyProvider() {
+        return memoize(ChecksumPolicyProvider.class, super.getChecksumPolicyProvider());
+    }
+
+    @Override
+    protected UpdateCheckManager getUpdateCheckManager(
+            TrackingFileManager trackingFileManager, UpdatePolicyAnalyzer updatePolicyAnalyzer) {
+        return memoize(
+                UpdateCheckManager.class, super.getUpdateCheckManager(trackingFileManager, updatePolicyAnalyzer));
+    }
+
+    @Override
+    protected Map<String, NamedLockFactory> getNamedLockFactories() {
+        return memoize(NamedLockFactory.class, super.getNamedLockFactories());
+    }
+
+    @Override
+    protected Map<String, NameMapper> getNameMappers() {
+        return memoize(NameMapper.class, super.getNameMappers());
+    }
+
+    @Override
+    protected NamedLockFactoryAdapterFactory getNamedLockFactoryAdapterFactory(
+            Map<String, NamedLockFactory> namedLockFactories,
+            Map<String, NameMapper> nameMappers,
+            RepositorySystemLifecycle repositorySystemLifecycle) {
+        return memoize(
+                NamedLockFactoryAdapterFactory.class,
+                super.getNamedLockFactoryAdapterFactory(namedLockFactories, nameMappers, repositorySystemLifecycle));
+    }
+
+    @Override
+    protected SyncContextFactory getSyncContextFactory(NamedLockFactoryAdapterFactory namedLockFactoryAdapterFactory) {
+        return memoize(SyncContextFactory.class, super.getSyncContextFactory(namedLockFactoryAdapterFactory));
+    }
+
+    @Override
+    protected Map<String, ChecksumAlgorithmFactory> getChecksumAlgorithmFactories() {
+        return memoize(ChecksumAlgorithmFactory.class, super.getChecksumAlgorithmFactories());
+    }
+
+    @Override
+    protected ChecksumAlgorithmFactorySelector getChecksumAlgorithmFactorySelector(
+            Map<String, ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
+        return memoize(
+                ChecksumAlgorithmFactorySelector.class,
+                super.getChecksumAlgorithmFactorySelector(checksumAlgorithmFactories));
+    }
+
+    @Override
+    protected Map<String, RepositoryLayoutFactory> getRepositoryLayoutFactories(
+            ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector) {
+        return memoize(
+                RepositoryLayoutFactory.class, super.getRepositoryLayoutFactories(checksumAlgorithmFactorySelector));
+    }
+
+    @Override
+    protected RepositoryLayoutProvider getRepositoryLayoutProvider(
+            Map<String, RepositoryLayoutFactory> repositoryLayoutFactories) {
+        return memoize(RepositoryLayoutProvider.class, super.getRepositoryLayoutProvider(repositoryLayoutFactories));
+    }
+
+    @Override
+    protected LocalRepositoryProvider getLocalRepositoryProvider(
+            LocalPathComposer localPathComposer,
+            TrackingFileManager trackingFileManager,
+            LocalPathPrefixComposerFactory localPathPrefixComposerFactory) {
+        return memoize(
+                LocalRepositoryProvider.class,
+                super.getLocalRepositoryProvider(
+                        localPathComposer, trackingFileManager, localPathPrefixComposerFactory));
+    }
+
+    @Override
+    protected RemoteRepositoryManager getRemoteRepositoryManager(
+            UpdatePolicyAnalyzer updatePolicyAnalyzer, ChecksumPolicyProvider checksumPolicyProvider) {
+        return memoize(
+                RemoteRepositoryManager.class,
+                super.getRemoteRepositoryManager(updatePolicyAnalyzer, checksumPolicyProvider));
+    }
+
+    @Override
+    protected Map<String, RemoteRepositoryFilterSource> getRemoteRepositoryFilterSources(
+            RepositorySystemLifecycle repositorySystemLifecycle, RepositoryLayoutProvider repositoryLayoutProvider) {
+        return memoize(
+                RemoteRepositoryFilterSource.class,
+                super.getRemoteRepositoryFilterSources(repositorySystemLifecycle, repositoryLayoutProvider));
+    }
+
+    @Override
+    protected RemoteRepositoryFilterManager getRemoteRepositoryFilterManager(
+            Map<String, RemoteRepositoryFilterSource> remoteRepositoryFilterSources) {
+        return memoize(
+                RemoteRepositoryFilterManager.class,
+                super.getRemoteRepositoryFilterManager(remoteRepositoryFilterSources));
+    }
+
+    @Override
+    protected Map<String, RepositoryListener> getRepositoryListeners() {
+        return memoize(RepositoryListener.class, super.getRepositoryListeners());
+    }
+
+    @Override
+    protected RepositoryEventDispatcher getRepositoryEventDispatcher(
+            Map<String, RepositoryListener> repositoryListeners) {
+        return memoize(RepositoryEventDispatcher.class, super.getRepositoryEventDispatcher(repositoryListeners));
+    }
+
+    @Override
+    protected Map<String, TrustedChecksumsSource> getTrustedChecksumsSources(
+            FileProcessor fileProcessor,
+            LocalPathComposer localPathComposer,
+            RepositorySystemLifecycle repositorySystemLifecycle) {
+        return memoize(
+                TrustedChecksumsSource.class,
+                super.getTrustedChecksumsSources(fileProcessor, localPathComposer, repositorySystemLifecycle));
+    }
+
+    @Override
+    protected Map<String, ProvidedChecksumsSource> getProvidedChecksumsSources(
+            Map<String, TrustedChecksumsSource> trustedChecksumsSources) {
+        return memoize(ProvidedChecksumsSource.class, super.getProvidedChecksumsSources(trustedChecksumsSources));
+    }
+
+    @Override
+    protected Map<String, ChecksumExtractor> getChecksumExtractors() {
+        return memoize(ChecksumExtractor.class, super.getChecksumExtractors());
+    }
+
+    @Override
+    protected Map<String, TransporterFactory> getTransporterFactories(Map<String, ChecksumExtractor> extractors) {
+        return memoize(TransporterFactory.class, super.getTransporterFactories(extractors));
+    }
+
+    @Override
+    protected TransporterProvider getTransporterProvider(Map<String, TransporterFactory> transporterFactories) {
+        return memoize(TransporterProvider.class, super.getTransporterProvider(transporterFactories));
+    }
+
+    @Override
+    protected BasicRepositoryConnectorFactory getBasicRepositoryConnectorFactory(
+            TransporterProvider transporterProvider,
+            RepositoryLayoutProvider repositoryLayoutProvider,
+            ChecksumPolicyProvider checksumPolicyProvider,
+            FileProcessor fileProcessor,
+            Map<String, ProvidedChecksumsSource> providedChecksumsSources) {
+        return memoize(
+                BasicRepositoryConnectorFactory.class,
+                super.getBasicRepositoryConnectorFactory(
+                        transporterProvider,
+                        repositoryLayoutProvider,
+                        checksumPolicyProvider,
+                        fileProcessor,
+                        providedChecksumsSources));
+    }
+
+    @Override
+    protected Map<String, RepositoryConnectorFactory> getRepositoryConnectorFactories(
+            BasicRepositoryConnectorFactory basicRepositoryConnectorFactory) {
+        return memoize(
+                RepositoryConnectorFactory.class,
+                super.getRepositoryConnectorFactories(basicRepositoryConnectorFactory));
+    }
+
+    @Override
+    protected RepositoryConnectorProvider getRepositoryConnectorProvider(
+            Map<String, RepositoryConnectorFactory> repositoryConnectorFactories,
+            RemoteRepositoryFilterManager remoteRepositoryFilterManager) {
+        return memoize(
+                RepositoryConnectorProvider.class,
+                super.getRepositoryConnectorProvider(repositoryConnectorFactories, remoteRepositoryFilterManager));
+    }
+
+    @Override
+    protected Installer getInstaller(
+            FileProcessor fileProcessor,
+            RepositoryEventDispatcher repositoryEventDispatcher,
+            Map<String, MetadataGeneratorFactory> metadataGeneratorFactories,
+            SyncContextFactory syncContextFactory) {
+        return memoize(
+                Installer.class,
+                super.getInstaller(
+                        fileProcessor, repositoryEventDispatcher, metadataGeneratorFactories, syncContextFactory));
+    }
+
+    @Override
+    protected Deployer getDeployer(
+            FileProcessor fileProcessor,
+            RepositoryEventDispatcher repositoryEventDispatcher,
+            RepositoryConnectorProvider repositoryConnectorProvider,
+            RemoteRepositoryManager remoteRepositoryManager,
+            UpdateCheckManager updateCheckManager,
+            Map<String, MetadataGeneratorFactory> metadataGeneratorFactories,
+            SyncContextFactory syncContextFactory,
+            OfflineController offlineController) {
+        return memoize(
+                Deployer.class,
+                super.getDeployer(
+                        fileProcessor,
+                        repositoryEventDispatcher,
+                        repositoryConnectorProvider,
+                        remoteRepositoryManager,
+                        updateCheckManager,
+                        metadataGeneratorFactories,
+                        syncContextFactory,
+                        offlineController));
+    }
+
+    @Override
+    protected Map<String, DependencyCollectorDelegate> getDependencyCollectorDelegates(
+            RemoteRepositoryManager remoteRepositoryManager,
+            ArtifactDescriptorReader artifactDescriptorReader,
+            VersionRangeResolver versionRangeResolver) {
+        return memoize(
+                DependencyCollectorDelegate.class,
+                super.getDependencyCollectorDelegates(
+                        remoteRepositoryManager, artifactDescriptorReader, versionRangeResolver));
+    }
+
+    @Override
+    protected DependencyCollector getDependencyCollector(
+            Map<String, DependencyCollectorDelegate> dependencyCollectorDelegates) {
+        return memoize(DependencyCollector.class, super.getDependencyCollector(dependencyCollectorDelegates));
+    }
+
+    @Override
+    protected Map<String, ArtifactResolverPostProcessor> getArtifactResolverPostProcessors(
+            ChecksumAlgorithmFactorySelector checksumAlgorithmFactorySelector,
+            Map<String, TrustedChecksumsSource> trustedChecksumsSources) {
+        return memoize(
+                ArtifactResolverPostProcessor.class,
+                super.getArtifactResolverPostProcessors(checksumAlgorithmFactorySelector, trustedChecksumsSources));
+    }
+
+    @Override
+    protected ArtifactResolver getArtifactResolver(
+            FileProcessor fileProcessor,
+            RepositoryEventDispatcher repositoryEventDispatcher,
+            VersionResolver versionResolver,
+            UpdateCheckManager updateCheckManager,
+            RepositoryConnectorProvider repositoryConnectorProvider,
+            RemoteRepositoryManager remoteRepositoryManager,
+            SyncContextFactory syncContextFactory,
+            OfflineController offlineController,
+            Map<String, ArtifactResolverPostProcessor> artifactResolverPostProcessors,
+            RemoteRepositoryFilterManager remoteRepositoryFilterManager) {
+        return memoize(
+                ArtifactResolver.class,
+                super.getArtifactResolver(
+                        fileProcessor,
+                        repositoryEventDispatcher,
+                        versionResolver,
+                        updateCheckManager,
+                        repositoryConnectorProvider,
+                        remoteRepositoryManager,
+                        syncContextFactory,
+                        offlineController,
+                        artifactResolverPostProcessors,
+                        remoteRepositoryFilterManager));
+    }
+
+    @Override
+    protected MetadataResolver getMetadataResolver(
+            RepositoryEventDispatcher repositoryEventDispatcher,
+            UpdateCheckManager updateCheckManager,
+            RepositoryConnectorProvider repositoryConnectorProvider,
+            RemoteRepositoryManager remoteRepositoryManager,
+            SyncContextFactory syncContextFactory,
+            OfflineController offlineController,
+            RemoteRepositoryFilterManager remoteRepositoryFilterManager) {
+        return memoize(
+                MetadataResolver.class,
+                super.getMetadataResolver(
+                        repositoryEventDispatcher,
+                        updateCheckManager,
+                        repositoryConnectorProvider,
+                        remoteRepositoryManager,
+                        syncContextFactory,
+                        offlineController,
+                        remoteRepositoryFilterManager));
+    }
+
+    @Override
+    protected Map<String, MetadataGeneratorFactory> getMetadataGeneratorFactories() {
+        return memoize(MetadataGeneratorFactory.class, super.getMetadataGeneratorFactories());
+    }
+
+    @Override
+    protected ArtifactDescriptorReader getArtifactDescriptorReader(
+            RemoteRepositoryManager remoteRepositoryManager,
+            VersionResolver versionResolver,
+            VersionRangeResolver versionRangeResolver,
+            ArtifactResolver artifactResolver,
+            ModelBuilder modelBuilder,
+            RepositoryEventDispatcher repositoryEventDispatcher,
+            ModelCacheFactory modelCacheFactory) {
+        return memoize(
+                ArtifactDescriptorReader.class,
+                super.getArtifactDescriptorReader(
+                        remoteRepositoryManager,
+                        versionResolver,
+                        versionRangeResolver,
+                        artifactResolver,
+                        modelBuilder,
+                        repositoryEventDispatcher,
+                        modelCacheFactory));
+    }
+
+    @Override
+    protected VersionResolver getVersionResolver(
+            MetadataResolver metadataResolver,
+            SyncContextFactory syncContextFactory,
+            RepositoryEventDispatcher repositoryEventDispatcher) {
+        return memoize(
+                VersionResolver.class,
+                super.getVersionResolver(metadataResolver, syncContextFactory, repositoryEventDispatcher));
+    }
+
+    @Override
+    protected VersionRangeResolver getVersionRangeResolver(
+            MetadataResolver metadataResolver,
+            SyncContextFactory syncContextFactory,
+            RepositoryEventDispatcher repositoryEventDispatcher) {
+        return memoize(
+                VersionRangeResolver.class,
+                super.getVersionRangeResolver(metadataResolver, syncContextFactory, repositoryEventDispatcher));
+    }
+
+    @Override
+    protected ModelBuilder getModelBuilder() {
+        return memoize(ModelBuilder.class, super.getModelBuilder());
+    }
+
+    @Override
+    protected ModelCacheFactory getModelCacheFactory() {
+        return memoize(ModelCacheFactory.class, super.getModelCacheFactory());
+    }
+}

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
@@ -32,12 +32,12 @@ import org.eclipse.aether.spi.synccontext.SyncContextFactory;
 import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.transport.http.ChecksumExtractor;
 
-public class MemoizingRepositorySystemSupplier extends RepositorySystemSupplier implements Lookup {
+public class MemoizingRepositorySystemSupplierLookup extends RepositorySystemSupplier implements Lookup {
     private final HashMap<Class<?>, Object> singulars = new HashMap<>();
 
     private final HashMap<Class<?>, Map<String, Object>> plurals = new HashMap<>();
 
-    public MemoizingRepositorySystemSupplier() {
+    public MemoizingRepositorySystemSupplierLookup() {
         memoize(RepositorySystem.class, super.get()); // to trigger filling up of memoized components
     }
 

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
@@ -46,12 +46,13 @@ public class MemoizingRepositorySystemSupplierLookup extends RepositorySystemSup
         return lookup(RepositorySystem.class).orElseThrow(() -> new NoSuchElementException("No value present"));
     }
 
-    private <T> T memoize(Class<T> key, T instance) {
+    protected <T> T memoize(Class<T> key, T instance) {
         singulars.put(key, instance);
         return instance;
     }
 
-    private <T> Map<String, T> memoize(Class<T> key, Map<String, T> instances) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected <T> Map<String, T> memoize(Class<T> key, Map<String, T> instances) {
         plurals.put(key, (Map) instances);
         return instances;
     }
@@ -66,6 +67,7 @@ public class MemoizingRepositorySystemSupplierLookup extends RepositorySystemSup
         return Optional.ofNullable(lookupMap(type).get(name));
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     private <T> Map<String, T> lookupMap(Class<T> type) {
         Map<String, T> result = (Map) plurals.get(type);
         if (result != null) {

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntime.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntime.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.mima.runtime.standalonestatic;
 import eu.maveniverse.maven.mima.context.Context;
 import eu.maveniverse.maven.mima.context.ContextOverrides;
 import eu.maveniverse.maven.mima.context.Lookup;
+import eu.maveniverse.maven.mima.context.internal.IteratingLookup;
 import eu.maveniverse.maven.mima.runtime.shared.PreBoot;
 import eu.maveniverse.maven.mima.runtime.shared.StandaloneRuntimeSupport;
 import java.util.NoSuchElementException;
@@ -36,15 +37,15 @@ public class StandaloneStaticRuntime extends StandaloneRuntimeSupport {
     @Override
     public Context create(ContextOverrides overrides) {
         PreBoot preBoot = preBoot(overrides);
-        Lookup lookup = new StaticLookup(preBoot);
-        RepositorySystem repositorySystem =
-                lookup.lookup(RepositorySystem.class).orElseThrow(() -> new NoSuchElementException("No value present"));
-        SettingsBuilder settingsBuilder =
-                lookup.lookup(SettingsBuilder.class).orElseThrow(() -> new NoSuchElementException("No value present"));
+        Lookup lookup = new IteratingLookup(createStaticLookup(preBoot), createRepositorySystemLookup(preBoot));
+        RepositorySystem repositorySystem = lookup.lookup(RepositorySystem.class)
+                .orElseThrow(() -> new NoSuchElementException("No RepositorySystem present"));
+        SettingsBuilder settingsBuilder = lookup.lookup(SettingsBuilder.class)
+                .orElseThrow(() -> new NoSuchElementException("No SettingsBuilder present"));
         SettingsDecrypter settingsDecrypter = lookup.lookup(SettingsDecrypter.class)
-                .orElseThrow(() -> new NoSuchElementException("No value present"));
-        ProfileSelector profileSelector =
-                lookup.lookup(ProfileSelector.class).orElseThrow(() -> new NoSuchElementException("No value present"));
+                .orElseThrow(() -> new NoSuchElementException("No SettingsDecrypter present"));
+        ProfileSelector profileSelector = lookup.lookup(ProfileSelector.class)
+                .orElseThrow(() -> new NoSuchElementException("No ProfileSelector present"));
         return buildContext(
                 this,
                 preBoot,
@@ -54,5 +55,13 @@ public class StandaloneStaticRuntime extends StandaloneRuntimeSupport {
                 profileSelector,
                 lookup,
                 repositorySystem::shutdown);
+    }
+
+    protected Lookup createStaticLookup(PreBoot preBoot) {
+        return new StaticLookup(preBoot);
+    }
+
+    protected Lookup createRepositorySystemLookup(PreBoot preBoot) {
+        return new MemoizingRepositorySystemSupplierLookup();
     }
 }

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntime.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntime.java
@@ -7,17 +7,16 @@
  */
 package eu.maveniverse.maven.mima.runtime.standalonestatic;
 
-import static java.util.Objects.requireNonNull;
-
 import eu.maveniverse.maven.mima.context.Context;
 import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.Lookup;
 import eu.maveniverse.maven.mima.runtime.shared.PreBoot;
 import eu.maveniverse.maven.mima.runtime.shared.StandaloneRuntimeSupport;
+import java.util.NoSuchElementException;
 import org.apache.maven.model.profile.ProfileSelector;
 import org.apache.maven.settings.building.SettingsBuilder;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.supplier.RepositorySystemSupplier;
 
 public class StandaloneStaticRuntime extends StandaloneRuntimeSupport {
 
@@ -37,10 +36,15 @@ public class StandaloneStaticRuntime extends StandaloneRuntimeSupport {
     @Override
     public Context create(ContextOverrides overrides) {
         PreBoot preBoot = preBoot(overrides);
-        RepositorySystem repositorySystem = requireNonNull(createRepositorySystem(preBoot));
-        SettingsBuilder settingsBuilder = requireNonNull(createSettingsBuilder(preBoot));
-        SettingsDecrypter settingsDecrypter = requireNonNull(createSettingsDecrypter(preBoot));
-        ProfileSelector profileSelector = requireNonNull(createProfileSelector(preBoot));
+        Lookup lookup = new StaticLookup(preBoot);
+        RepositorySystem repositorySystem =
+                lookup.lookup(RepositorySystem.class).orElseThrow(() -> new NoSuchElementException("No value present"));
+        SettingsBuilder settingsBuilder =
+                lookup.lookup(SettingsBuilder.class).orElseThrow(() -> new NoSuchElementException("No value present"));
+        SettingsDecrypter settingsDecrypter = lookup.lookup(SettingsDecrypter.class)
+                .orElseThrow(() -> new NoSuchElementException("No value present"));
+        ProfileSelector profileSelector =
+                lookup.lookup(ProfileSelector.class).orElseThrow(() -> new NoSuchElementException("No value present"));
         return buildContext(
                 this,
                 preBoot,
@@ -48,22 +52,7 @@ public class StandaloneStaticRuntime extends StandaloneRuntimeSupport {
                 settingsBuilder,
                 settingsDecrypter,
                 profileSelector,
+                lookup,
                 repositorySystem::shutdown);
-    }
-
-    protected RepositorySystem createRepositorySystem(PreBoot preBoot) {
-        return new RepositorySystemSupplier().get();
-    }
-
-    protected SettingsBuilder createSettingsBuilder(PreBoot preBoot) {
-        return new SettingsBuilderSupplier().get();
-    }
-
-    protected SettingsDecrypter createSettingsDecrypter(PreBoot preBoot) {
-        return new SettingsDecrypterSupplier(preBoot.getMavenUserHome()).get();
-    }
-
-    protected ProfileSelector createProfileSelector(PreBoot preBoot) {
-        return new ProfileSelectorSupplier().get();
     }
 }

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StaticLookup.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StaticLookup.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.mima.context.Lookup;
 import eu.maveniverse.maven.mima.runtime.shared.PreBoot;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.maven.model.profile.ProfileSelector;
 import org.apache.maven.settings.building.SettingsBuilder;
@@ -41,10 +40,5 @@ public class StaticLookup implements Lookup {
     @Override
     public <T> Optional<T> lookup(Class<T> type, String name) {
         return repositorySystemSupplier.lookup(type, name);
-    }
-
-    @Override
-    public <T> Map<String, T> lookupMap(Class<T> type) {
-        return repositorySystemSupplier.lookupMap(type);
     }
 }

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StaticLookup.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StaticLookup.java
@@ -1,0 +1,50 @@
+package eu.maveniverse.maven.mima.runtime.standalonestatic;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.mima.context.Lookup;
+import eu.maveniverse.maven.mima.runtime.shared.PreBoot;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.maven.model.profile.ProfileSelector;
+import org.apache.maven.settings.building.SettingsBuilder;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+
+public class StaticLookup implements Lookup {
+    private final ProfileSelector profileSelector;
+    private final SettingsBuilder settingsBuilder;
+    private final SettingsDecrypter settingsDecrypter;
+    private final MemoizingRepositorySystemSupplier repositorySystemSupplier;
+
+    public StaticLookup(PreBoot preBoot) {
+        requireNonNull(preBoot);
+        this.profileSelector = new ProfileSelectorSupplier().get();
+        this.settingsBuilder = new SettingsBuilderSupplier().get();
+        this.settingsDecrypter = new SettingsDecrypterSupplier(preBoot.getMavenUserHome()).get();
+        this.repositorySystemSupplier = new MemoizingRepositorySystemSupplier();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> Optional<T> lookup(Class<T> type) {
+        if (type.isAssignableFrom(ProfileSelector.class)) {
+            return (Optional<T>) Optional.of(profileSelector);
+        } else if (type.isAssignableFrom(SettingsBuilder.class)) {
+            return (Optional<T>) Optional.of(settingsBuilder);
+        } else if (type.isAssignableFrom(SettingsDecrypter.class)) {
+            return (Optional<T>) Optional.of(settingsDecrypter);
+        } else {
+            return repositorySystemSupplier.lookup(type);
+        }
+    }
+
+    @Override
+    public <T> Optional<T> lookup(Class<T> type, String name) {
+        return repositorySystemSupplier.lookup(type, name);
+    }
+
+    @Override
+    public <T> Map<String, T> lookupMap(Class<T> type) {
+        return repositorySystemSupplier.lookupMap(type);
+    }
+}

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StaticLookup.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StaticLookup.java
@@ -13,14 +13,12 @@ public class StaticLookup implements Lookup {
     private final ProfileSelector profileSelector;
     private final SettingsBuilder settingsBuilder;
     private final SettingsDecrypter settingsDecrypter;
-    private final MemoizingRepositorySystemSupplier repositorySystemSupplier;
 
     public StaticLookup(PreBoot preBoot) {
         requireNonNull(preBoot);
         this.profileSelector = new ProfileSelectorSupplier().get();
         this.settingsBuilder = new SettingsBuilderSupplier().get();
         this.settingsDecrypter = new SettingsDecrypterSupplier(preBoot.getMavenUserHome()).get();
-        this.repositorySystemSupplier = new MemoizingRepositorySystemSupplier();
     }
 
     @SuppressWarnings("unchecked")
@@ -33,12 +31,15 @@ public class StaticLookup implements Lookup {
         } else if (type.isAssignableFrom(SettingsDecrypter.class)) {
             return (Optional<T>) Optional.of(settingsDecrypter);
         } else {
-            return repositorySystemSupplier.lookup(type);
+            return Optional.empty();
         }
     }
 
     @Override
     public <T> Optional<T> lookup(Class<T> type, String name) {
-        return repositorySystemSupplier.lookup(type, name);
+        if ("".equals(name) || "default".equals(name)) {
+            return lookup(type);
+        }
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
Introduce a `Lookup` on context to be able to reach some Resolver components. Add demo doing it as well (and demo runs with "static" and "sisu" standalone runtimes, but also embedded in maven as "maven-plugin").

Fixes #94 