### PR TITLE
MMR Repositories can be overridden and should be exposed

### DIFF
--- a/extensions/mmr/pom.xml
+++ b/extensions/mmr/pom.xml
@@ -77,6 +77,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/MavenModelReader.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/MavenModelReader.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  *     perform it manually: inspect the effective model and based on {@link org.apache.maven.model.Relocation}
  *     issue another request for relocation target.</li>
  *     <li>Does not obey {@link RepositorySystemSession#getArtifactDescriptorPolicy()}, if asked artifact does not
- *     exists, it will fail.</li>
+ *     exist, it will fail.</li>
  *     <li>If passed in {@link Artifact} is resolved ({@link Artifact#getFile()} returns non-{@code null} value), then
  *     model will be read from that file directly. Naturally, to be able to build the model, the possible
  *     parent and other POMs must be resolvable.</li>
@@ -44,6 +44,10 @@ public class MavenModelReader {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final MavenModelReaderImpl mavenModelReaderImpl;
 
+    /**
+     * Creates instance using passed in context. As context carries "root" remote repositories, they be used
+     * by default. They can be overridden in request.
+     */
     public MavenModelReader(Context context) {
         requireNonNull(context, "context");
         this.mavenModelReaderImpl = new MavenModelReaderImpl(context);
@@ -51,6 +55,10 @@ public class MavenModelReader {
 
     /**
      * Reads POM as {@link ModelResponse}.
+     * <p>
+     * Remark related to repositories: by default context "root" remote repositories will be used, unless
+     * request {@link ModelRequest#getRepositories()} returns non-null value, in which case request provided
+     * repositories will be used.
      */
     public ModelResponse readModel(ModelRequest request)
             throws VersionResolutionException, ArtifactResolutionException, ArtifactDescriptorException {

--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/MavenModelReader.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/MavenModelReader.java
@@ -45,8 +45,8 @@ public class MavenModelReader {
     private final MavenModelReaderImpl mavenModelReaderImpl;
 
     /**
-     * Creates instance using passed in context. As context carries "root" remote repositories, they be used
-     * by default. They can be overridden in request.
+     * Creates instance using passed in context. As context carries "root" remote repositories, they are used
+     * by default, but can be overridden in {@link ModelRequest}.
      */
     public MavenModelReader(Context context) {
         requireNonNull(context, "context");

--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/ModelRequest.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/ModelRequest.java
@@ -10,6 +10,8 @@ package eu.maveniverse.maven.mima.extensions.mmr;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.eclipse.aether.RequestTrace;
 import org.eclipse.aether.artifact.Artifact;
@@ -73,7 +75,11 @@ public class ModelRequest {
         }
 
         public ModelRequest build() {
-            return new ModelRequest(artifact, repositories, requestContext, trace);
+            return new ModelRequest(
+                    artifact,
+                    repositories != null ? Collections.unmodifiableList(new ArrayList<>(repositories)) : null,
+                    requestContext,
+                    trace);
         }
 
         /**

--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/ModelRequest.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/ModelRequest.java
@@ -25,12 +25,12 @@ public class ModelRequest {
     }
 
     private final Artifact artifact;
+    private final List<RemoteRepository> repositories;
     private final String requestContext;
     private final RequestTrace trace;
-    private final List<RemoteRepository> repositories;
 
     private ModelRequest(
-            Artifact artifact, String requestContext, RequestTrace trace, List<RemoteRepository> repositories) {
+            Artifact artifact, List<RemoteRepository> repositories, String requestContext, RequestTrace trace) {
         this.artifact = requireNonNull(artifact);
         this.requestContext = requestContext == null ? "" : requestContext;
         this.trace = trace;
@@ -41,16 +41,16 @@ public class ModelRequest {
         return artifact;
     }
 
+    public List<RemoteRepository> getRepositories() {
+        return repositories;
+    }
+
     public String getRequestContext() {
         return requestContext;
     }
 
     public RequestTrace getTrace() {
         return trace;
-    }
-
-    public List<RemoteRepository> getRepositories() {
-        return repositories;
     }
 
     public Builder toBuilder() {
@@ -67,38 +67,56 @@ public class ModelRequest {
 
         private Builder(ModelRequest request) {
             this.artifact = request.artifact;
+            this.repositories = request.repositories;
             this.requestContext = request.requestContext;
             this.trace = request.trace;
-            this.repositories = request.repositories;
         }
 
         public ModelRequest build() {
-            return new ModelRequest(artifact, requestContext, trace, repositories);
+            return new ModelRequest(artifact, repositories, requestContext, trace);
         }
 
+        /**
+         * Make possible to point at a POM anywhere on file system, to have it built. Naturally, all the required
+         * bits like parent POM, imported POM must be still resolvable (from local or remote repositories).
+         */
         public Builder setPomFile(Path pomFile) {
             requireNonNull(pomFile);
             return setArtifact(new DefaultArtifact("irrelevant:irrelevant:irrelevant").setFile(pomFile.toFile()));
         }
 
+        /**
+         * Sets the artifact whose POM we want to build model for. The artifact must be resolvable from local or
+         * remote repositories.
+         */
         public Builder setArtifact(Artifact artifact) {
             requireNonNull(artifact);
             this.artifact = artifact;
             return this;
         }
 
+        /**
+         * Optionally, user may want to override context "root" repositories with own set (ie appended or totally new
+         * list of repositories).
+         */
+        public Builder setRepositories(List<RemoteRepository> repositories) {
+            this.repositories = repositories;
+            return this;
+        }
+
+        /**
+         * Sets the request context for bookkeeping purposes.
+         */
         public Builder setRequestContext(String requestContext) {
             this.requestContext = requestContext;
             return this;
         }
 
+        /**
+         * Sets the request trace for bookkeeping purposes.
+         */
         public Builder setTrace(RequestTrace trace) {
             this.trace = trace;
-            return this;
-        }
-
-        public Builder setRepositories(List<RemoteRepository> repositories) {
-            this.repositories = repositories;
             return this;
         }
     }

--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/ModelResponse.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/ModelResponse.java
@@ -12,6 +12,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.function.Function;
 import org.apache.maven.model.Model;
+import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 
 /**
@@ -23,6 +24,7 @@ import org.eclipse.aether.resolution.ArtifactDescriptorResult;
 public class ModelResponse {
     private final Model rawModel;
     private final Model effectiveModel;
+    private final ArtifactRepository repository;
     private final Function<Model, ArtifactDescriptorResult> converter;
     private final List<String> lineage;
     private final Function<String, Model> lineageFunction;
@@ -31,12 +33,14 @@ public class ModelResponse {
     public ModelResponse(
             Model rawModel,
             Model effectiveModel,
+            ArtifactRepository repository,
             Function<Model, ArtifactDescriptorResult> converter,
             List<String> lineage,
             Function<String, Model> lineageFunction,
             Function<Model, Model> interpolatorFunction) {
         this.rawModel = requireNonNull(rawModel);
         this.effectiveModel = requireNonNull(effectiveModel);
+        this.repository = repository;
         this.converter = requireNonNull(converter);
         this.lineage = requireNonNull(lineage);
         this.lineageFunction = requireNonNull(lineageFunction);
@@ -61,6 +65,13 @@ public class ModelResponse {
      */
     public Model getRawModel() {
         return rawModel;
+    }
+
+    /**
+     * Gets the repository from which the descriptor was eventually resolved or {@code null} if unknown.
+     */
+    public ArtifactRepository getRepository() {
+        return repository;
     }
 
     /**

--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/internal/MavenModelReaderImpl.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/internal/MavenModelReaderImpl.java
@@ -106,14 +106,14 @@ public class MavenModelReaderImpl {
 
     private ModelResponse loadPom(RepositorySystemSession session, ModelRequest request)
             throws VersionResolutionException, ArtifactResolutionException, ArtifactDescriptorException {
+        List<RemoteRepository> repositories = this.repositories;
+        if (request.getRepositories() != null) {
+            repositories = repositorySystem.newResolutionRepositories(session, request.getRepositories());
+        }
+
         ArtifactDescriptorRequest artifactDescriptorRequest = new ArtifactDescriptorRequest();
         artifactDescriptorRequest.setArtifact(request.getArtifact());
-        if (request.getRepositories() != null) {
-            artifactDescriptorRequest.setRepositories(
-                    repositorySystem.newResolutionRepositories(session, request.getRepositories()));
-        } else {
-            artifactDescriptorRequest.setRepositories(this.repositories);
-        }
+        artifactDescriptorRequest.setRepositories(repositories);
         artifactDescriptorRequest.setRequestContext(request.getRequestContext());
         artifactDescriptorRequest.setTrace(request.getTrace());
         ArtifactDescriptorResult artifactDescriptorResult = new ArtifactDescriptorResult(artifactDescriptorRequest);

--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/internal/MavenModelReaderImpl.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/internal/MavenModelReaderImpl.java
@@ -109,7 +109,8 @@ public class MavenModelReaderImpl {
         ArtifactDescriptorRequest artifactDescriptorRequest = new ArtifactDescriptorRequest();
         artifactDescriptorRequest.setArtifact(request.getArtifact());
         if (request.getRepositories() != null) {
-            artifactDescriptorRequest.setRepositories(request.getRepositories());
+            artifactDescriptorRequest.setRepositories(
+                    repositorySystem.newResolutionRepositories(session, request.getRepositories()));
         } else {
             artifactDescriptorRequest.setRepositories(this.repositories);
         }
@@ -236,6 +237,7 @@ public class MavenModelReaderImpl {
             return new ModelResponse(
                     modelResult.getRawModel().clone(),
                     modelResult.getEffectiveModel().clone(),
+                    artifactDescriptorResult.getRepository(),
                     m -> {
                         ArtifactDescriptorResult r = new ArtifactDescriptorResult(artifactDescriptorRequest);
                         r.setRepository(artifactDescriptorResult.getRepository());

--- a/extensions/mmr/src/test/java/eu/maveniverse/maven/mima/extensions/mmr/MavenModelReaderTest.java
+++ b/extensions/mmr/src/test/java/eu/maveniverse/maven/mima/extensions/mmr/MavenModelReaderTest.java
@@ -53,7 +53,7 @@ public class MavenModelReaderTest {
             // REPO
             ArtifactRepository responseRepository = response.getRepository();
             if (overrideRepository == null) {
-                assertEquals(responseRepository, context.remoteRepositories().get(0));
+                assertEquals(context.remoteRepositories().get(0), responseRepository);
             } else {
                 assertEquals(overrideRepository, responseRepository);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <version.maven>3.9.9</version.maven>
     <version.sisu>0.9.0.M3</version.sisu>
     <version.slf4j>1.7.36</version.slf4j>
+    <version.junit>5.11.4</version.junit>
   </properties>
 
   <dependencyManagement>
@@ -241,7 +242,12 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.11.4</version>
+        <version>${version.junit}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>${version.junit}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Changes:
* make sure passed in repositories are fully prepared for resolving (auth, proxy, mirror etc)
* expose repository of origin, no need to make hoops and loops (ask for irrelevant Resolver type just to get it)