### PR TITLE
Support profile activation via file if a regular pom.xml of a project is read

### DIFF
--- a/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/internal/MavenModelReaderImpl.java
+++ b/extensions/mmr/src/main/java/eu/maveniverse/maven/mima/extensions/mmr/internal/MavenModelReaderImpl.java
@@ -184,6 +184,7 @@ public class MavenModelReaderImpl {
                 modelRequest.setPomFile(pomArtifact.getFile());
             } else {
                 modelRequest.setModelSource(new FileModelSource(pomArtifact.getFile()));
+                modelRequest.setPomFile(pomArtifact.getFile());
             }
 
             ModelBuildingResult modelResult = modelBuilder.build(modelRequest);


### PR DESCRIPTION
The reason is that the activation context uses the pomFile property of the building request to determine the project directory.
See https://github.com/apache/maven/blob/5f519b97e944483d878815739f519b2eade0a91d/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java#L668