### PR TITLE
Fix NPE when customizing context

### DIFF
--- a/context/pom.xml
+++ b/context/pom.xml
@@ -39,5 +39,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.18.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupport.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupport.java
@@ -131,7 +131,9 @@ public abstract class RuntimeSupport implements Runtime {
                 overrides,
                 overrides.getBasedirOverride() != null ? overrides.getBasedirOverride() : context.basedir(),
                 ((MavenUserHomeImpl) context.mavenUserHome()).derive(overrides),
-                ((MavenSystemHomeImpl) context.mavenSystemHome()).derive(overrides),
+                context.mavenSystemHome() != null
+                        ? ((MavenSystemHomeImpl) context.mavenSystemHome()).derive(overrides)
+                        : null,
                 context.repositorySystem(),
                 session,
                 Collections.unmodifiableList(

--- a/context/src/test/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupportTest.java
+++ b/context/src/test/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupportTest.java
@@ -1,0 +1,73 @@
+package eu.maveniverse.maven.mima.context.internal;
+
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.Lookup;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RuntimeSupportTest {
+    @Test
+    void itPropagatesNullMavenSystemHome() {
+        RuntimeSupport runtimeSupport = new RuntimeSupport("test", "123", 999, "123") {
+            @Override
+            public boolean managedRepositorySystem() {
+                return false;
+            }
+
+            @Override
+            public Context create(ContextOverrides overrides) {
+                return null;
+            }
+
+            @Override
+            protected void customizeLocalRepositoryManager(Context context, DefaultRepositorySystemSession session) {
+                // Intentionally skipped
+            }
+
+            @Override
+            protected List<RemoteRepository> customizeRemoteRepositories(
+                    ContextOverrides contextOverrides, List<RemoteRepository> remoteRepositories) {
+                // Intentionally skipped
+                return remoteRepositories;
+            }
+        };
+
+        Context context = new Context(
+                runtimeSupport,
+                ContextOverrides.create().build(),
+                Paths.get("/test"),
+                runtimeSupport.defaultMavenUserHome(),
+                null,
+                Mockito.mock(RepositorySystem.class),
+                Mockito.mock(RepositorySystemSession.class),
+                new ArrayList<>(),
+                null,
+                new Lookup() {
+                    @Override
+                    public <T> Optional<T> lookup(Class<T> type) {
+                        return Optional.empty();
+                    }
+
+                    @Override
+                    public <T> Optional<T> lookup(Class<T> type, String name) {
+                        return Optional.empty();
+                    }
+                },
+                null);
+
+        ContextOverrides overrides =
+                ContextOverrides.create().offline(Boolean.TRUE).build();
+
+        Assertions.assertDoesNotThrow(() -> runtimeSupport.customizeContext(overrides, context, false));
+    }
+}


### PR DESCRIPTION
If you do not provide a MavenSystemHome when creating a Runtime, attempts to customize the context on that runtime will fail with an NPE because the customize method attempts to invoke `derive` without a null guard. Aside from customizing the context, MIMA works as expected with a null maven system home, so the simplest fix is to add a null guard.

I also included a test case.