### PR TITLE
Bug: when in embedded-maven it still overrides repositories

### DIFF
--- a/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
+++ b/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
@@ -99,19 +99,21 @@ public final class MavenRuntime extends RuntimeSupport {
 
         List<RemoteRepository> repositories =
                 new ArrayList<>(mavenSession.getCurrentProject().getRemoteProjectRepositories());
-        switch (overrides.addRepositoriesOp()) {
-            case REPLACE:
-                repositories.clear();
-                repositories.addAll(overrides.getRepositories());
-                break;
-            case PREPEND:
-                repositories.addAll(0, overrides.getRepositories());
-                break;
-            case APPEND:
-                repositories.addAll(overrides.getRepositories());
-                break;
-            default:
-                throw new IllegalStateException("Unknown overrides op: " + overrides.addRepositoriesOp());
+        if (overrides.getRepositories() != ContextOverrides.DEFAULT_REMOTE_REPOSITORIES) {
+            switch (overrides.addRepositoriesOp()) {
+                case REPLACE:
+                    repositories.clear();
+                    repositories.addAll(overrides.getRepositories());
+                    break;
+                case PREPEND:
+                    repositories.addAll(0, overrides.getRepositories());
+                    break;
+                case APPEND:
+                    repositories.addAll(overrides.getRepositories());
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown overrides op: " + overrides.addRepositoriesOp());
+            }
         }
 
         MavenUserHome mavenUserHome = discoverMavenUserHome(mavenSession.getRequest());


### PR DESCRIPTION
When in embedded-maven AND user does not touched repository overrides, we want to get what Maven have, exactly.

This was not happening, as override always happened in fact.