### PR TITLE
Expose resolver version

### DIFF
--- a/context/src/main/java/eu/maveniverse/maven/mima/context/Runtime.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/Runtime.java
@@ -11,6 +11,12 @@ package eu.maveniverse.maven.mima.context;
  * Runtime is a factory for {@link Context} instances.
  */
 public interface Runtime {
+    /**
+     * String representation returned for versions, when discovery was unsuccessful.
+     *
+     * @since 2.4.38
+     */
+    String UNKNOWN_VERSION = "(unknown)";
 
     /**
      * The runtime name (mostly for keying purposes), never {@code null}.
@@ -32,6 +38,16 @@ public interface Runtime {
      * "maven models" version, except when MIMA runs inside of Maven, when it carries the "actual Maven version".
      */
     String mavenVersion();
+
+    /**
+     * Returns a string representing Resolver version this runtime uses, never {@code null}. In case of embedded
+     * Maven, discovery of resolver is not possible due Maven classloader encapsulation (then resolver version
+     * can be derived from Maven version).
+     *
+     * @since 2.4.38
+     * @return discovered resolver version or {@link #UNKNOWN_VERSION}
+     */
+    String resolverVersion();
 
     /**
      * Returns {@code true} if this runtime creates managed repository system, that is opposite when MIMA runs

--- a/context/src/test/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupportTest.java
+++ b/context/src/test/java/eu/maveniverse/maven/mima/context/internal/RuntimeSupportTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mockito;
 class RuntimeSupportTest {
     @Test
     void itPropagatesNullMavenSystemHome() {
-        RuntimeSupport runtimeSupport = new RuntimeSupport("test", "123", 999, "123") {
+        RuntimeSupport runtimeSupport = new RuntimeSupport("test", "123", 999, "123", "123") {
             @Override
             public boolean managedRepositorySystem() {
                 return false;

--- a/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
+++ b/runtime/embedded-maven/src/main/java/eu/maveniverse/maven/mima/runtime/maven/MavenRuntime.java
@@ -56,9 +56,12 @@ public final class MavenRuntime extends RuntimeSupport {
             @Nullable RuntimeInformation rt) {
         super(
                 "embedded-maven",
-                discoverArtifactVersion("eu.maveniverse.maven.mima.runtime", "embedded-maven", UNKNOWN),
+                discoverArtifactVersion(
+                        MavenRuntime.class, "eu.maveniverse.maven.mima.runtime", "embedded-maven", UNKNOWN_VERSION),
                 10,
-                mavenVersion(rt));
+                mavenVersion(rt),
+                "embedded");
+        // when embedded in Maven, classloading isolation does not allow us to discover Resolver version
         this.repositorySystem = repositorySystem;
         this.plexusContainer = plexusContainer;
         this.mavenSessionProvider = mavenSessionProvider;
@@ -76,7 +79,7 @@ public final class MavenRuntime extends RuntimeSupport {
                 return mavenVersion;
             }
         }
-        return UNKNOWN;
+        return UNKNOWN_VERSION;
     }
 
     @Override

--- a/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
+++ b/runtime/standalone-shared/src/main/java/eu/maveniverse/maven/mima/runtime/shared/StandaloneRuntimeSupport.java
@@ -75,15 +75,16 @@ public abstract class StandaloneRuntimeSupport extends RuntimeSupport {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected StandaloneRuntimeSupport(String name, int priority) {
-        super(name, discoverVersion(), priority, discoverMavenVersion());
+        super(name, discoverVersion(), priority, discoverMavenVersion(), discoverResolverVersion());
     }
 
     private static String discoverVersion() {
-        Map<String, String> version =
-                loadClasspathProperties("/eu/maveniverse/maven/mima/runtime/shared/internal/version.properties");
+        Map<String, String> version = loadClasspathProperties(
+                StandaloneRuntimeSupport.class,
+                "/eu/maveniverse/maven/mima/runtime/shared/internal/version.properties");
         String result = version.get("version");
         if (result == null || result.trim().isEmpty() || result.startsWith("${")) {
-            return UNKNOWN;
+            return UNKNOWN_VERSION;
         }
         return result;
     }


### PR DESCRIPTION
When possible. When embedded in Maven, classloader isolation prevents us to discover, but Maven version implicitly reveals resolver version as well (check release notes of it or check the `/lib`). When standalone, discovery is usable and is used, as MIMA never delivers 'full maven' so it can combine those two with minor differences between real Maven distro releases.