### PR TITLE
Static extensions

### DIFF
--- a/context/src/main/java/eu/maveniverse/maven/mima/context/ContextOverrides.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/ContextOverrides.java
@@ -124,6 +124,8 @@ public final class ContextOverrides {
 
     private final Object effectiveSettingsMixin;
 
+    private final Map<Class<?>, Map<String, Object>> staticExtensions;
+
     private ContextOverrides(
             final Path basedirOverride,
             final Map<String, String> systemProperties,
@@ -152,7 +154,8 @@ public final class ContextOverrides {
             final Path globalSettingsXmlOverride,
             final Path globalToolchainsXmlOverride,
             final Object effectiveSettings,
-            final Object effectiveSettingsMixin) {
+            final Object effectiveSettingsMixin,
+            final Map<Class<?>, Map<String, Object>> staticExtensions) {
 
         this.basedirOverride = basedirOverride;
         this.systemProperties = Collections.unmodifiableMap(systemProperties);
@@ -186,6 +189,8 @@ public final class ContextOverrides {
         this.globalToolchainsXmlOverride = globalToolchainsXmlOverride;
         this.effectiveSettings = effectiveSettings;
         this.effectiveSettingsMixin = effectiveSettingsMixin;
+        this.staticExtensions =
+                staticExtensions == null ? Collections.emptyMap() : Collections.unmodifiableMap(staticExtensions);
     }
 
     /**
@@ -422,6 +427,17 @@ public final class ContextOverrides {
     }
 
     /**
+     * Used in static runtime only: return the user-set static extensions map, that may contain SPI instances
+     * to be hooked into Resolver. Dangerous! If you don't know what you are doing, ask first. In non-static
+     * runtime case, you should rely on usual component discovery, as this field is used only by static runtime.
+     *
+     * @since 2.4.46
+     */
+    public Map<Class<?>, Map<String, Object>> getStaticExtensions() {
+        return staticExtensions;
+    }
+
+    /**
      * Creates {@link Builder} out of current instance.
      *
      * @since 2.4.0
@@ -455,7 +471,8 @@ public final class ContextOverrides {
                 .withGlobalSettingsXmlOverride(globalSettingsXmlOverride)
                 .withGlobalToolchainsXmlOverride(globalToolchainsXmlOverride)
                 .withEffectiveSettings(effectiveSettings)
-                .withEffectiveSettingsMixin(effectiveSettingsMixin);
+                .withEffectiveSettingsMixin(effectiveSettingsMixin)
+                .withStaticExtensions(staticExtensions);
     }
 
     @Override
@@ -494,7 +511,8 @@ public final class ContextOverrides {
                 && Objects.equals(globalSettingsXmlOverride, that.globalSettingsXmlOverride)
                 && Objects.equals(globalToolchainsXmlOverride, that.globalToolchainsXmlOverride)
                 && Objects.equals(effectiveSettings, that.effectiveSettings)
-                && Objects.equals(effectiveSettingsMixin, that.effectiveSettingsMixin);
+                && Objects.equals(effectiveSettingsMixin, that.effectiveSettingsMixin)
+                && Objects.equals(staticExtensions, that.staticExtensions);
     }
 
     @Override
@@ -527,7 +545,8 @@ public final class ContextOverrides {
                 globalSettingsXmlOverride,
                 globalToolchainsXmlOverride,
                 effectiveSettings,
-                effectiveSettingsMixin);
+                effectiveSettingsMixin,
+                staticExtensions);
     }
 
     /**
@@ -596,6 +615,8 @@ public final class ContextOverrides {
         private Object effectiveSettings = null;
 
         private Object effectiveSettingsMixin = null;
+
+        private Map<Class<?>, Map<String, Object>> staticExtensions = Collections.emptyMap();
 
         /**
          * Hide ctor, use {@link #create()} to create new builder instances.
@@ -918,6 +939,17 @@ public final class ContextOverrides {
         }
 
         /**
+         * Sets user set static extensions to Resolver/MIMA. Used only in static runtime. With Sisu runtime, one should
+         * rely on usual component discovery instead, and this field is unused.
+         *
+         * @since 2.4.46
+         */
+        public Builder withStaticExtensions(Map<Class<?>, Map<String, Object>> staticExtensions) {
+            this.staticExtensions = requireNonNull(staticExtensions);
+            return this;
+        }
+
+        /**
          * Builds an immutable instance of {@link ContextOverrides} using so far applied settings and configuration.
          */
         public ContextOverrides build() {
@@ -949,7 +981,8 @@ public final class ContextOverrides {
                     globalSettingsXmlOverride,
                     globalToolchainsXmlOverride,
                     effectiveSettings,
-                    effectiveSettingsMixin);
+                    effectiveSettingsMixin,
+                    staticExtensions);
         }
     }
 }

--- a/context/src/main/java/eu/maveniverse/maven/mima/context/ContextOverrides.java
+++ b/context/src/main/java/eu/maveniverse/maven/mima/context/ContextOverrides.java
@@ -940,12 +940,12 @@ public final class ContextOverrides {
 
         /**
          * Sets user set static extensions to Resolver/MIMA. Used only in static runtime. With Sisu runtime, one should
-         * rely on usual component discovery instead, and this field is unused.
+         * rely on usual component discovery instead, and this field is unused. Allows {@code null}, means "no extensions".
          *
          * @since 2.4.46
          */
         public Builder withStaticExtensions(Map<Class<?>, Map<String, Object>> staticExtensions) {
-            this.staticExtensions = requireNonNull(staticExtensions);
+            this.staticExtensions = staticExtensions;
             return this;
         }
 

--- a/runtime/standalone-sisu/pom.xml
+++ b/runtime/standalone-sisu/pom.xml
@@ -92,5 +92,16 @@
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/runtime/standalone-sisu/src/test/java/eu/maveniverse/maven/mima/runtime/standalonesisu/StandaloneSisuRuntimeTest.java
+++ b/runtime/standalone-sisu/src/test/java/eu/maveniverse/maven/mima/runtime/standalonesisu/StandaloneSisuRuntimeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.mima.runtime.standalonesisu;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
+import eu.maveniverse.maven.mima.context.Runtime;
+import eu.maveniverse.maven.mima.context.internal.MavenUserHomeImpl;
+import eu.maveniverse.maven.mima.runtime.shared.PreBoot;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionResult;
+import org.eclipse.sisu.space.BeanScanning;
+import org.eclipse.sisu.space.SpaceModule;
+import org.eclipse.sisu.space.URLClassSpace;
+import org.eclipse.sisu.wire.WireModule;
+import org.junit.jupiter.api.Test;
+
+@Named
+public class StandaloneSisuRuntimeTest extends AbstractModule {
+    @Inject
+    private Runtime runtime;
+
+    @Override
+    protected void configure() {
+        try {
+            ContextOverrides overrides = ContextOverrides.create().build();
+            Path baseDir = Paths.get("target/basedir");
+            Files.createDirectories(baseDir);
+            bind(PreBoot.class).toInstance(new PreBoot(overrides, new MavenUserHomeImpl(baseDir), null, baseDir));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    void smoke() {
+        ClassLoader classloader = StandaloneSisuRuntime.class.getClassLoader();
+        Guice.createInjector(new WireModule(new SpaceModule(new URLClassSpace(classloader), BeanScanning.ON, true)))
+                .injectMembers(this);
+        try (Context context = runtime.create(ContextOverrides.create().build())) {
+            VersionResult versionResult = context.repositorySystem()
+                    .resolveVersion(
+                            context.repositorySystemSession(),
+                            new VersionRequest(
+                                    new DefaultArtifact("eu.maveniverse.maven.mima:context:LATEST"),
+                                    context.remoteRepositories(),
+                                    "test"));
+            // dynamic version should be resolved to some static version
+            assertNotEquals("LATEST", versionResult.getVersion());
+        } catch (VersionResolutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/runtime/standalone-sisu/src/test/java/eu/maveniverse/maven/mima/runtime/standalonesisu/StandaloneSisuRuntimeTest.java
+++ b/runtime/standalone-sisu/src/test/java/eu/maveniverse/maven/mima/runtime/standalonesisu/StandaloneSisuRuntimeTest.java
@@ -55,7 +55,9 @@ public class StandaloneSisuRuntimeTest extends AbstractModule {
         ClassLoader classloader = StandaloneSisuRuntime.class.getClassLoader();
         Guice.createInjector(new WireModule(new SpaceModule(new URLClassSpace(classloader), BeanScanning.ON, true)))
                 .injectMembers(this);
-        try (Context context = runtime.create(ContextOverrides.create().build())) {
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withLocalRepositoryOverride(Paths.get("target/local-repo"))
+                .build())) {
             VersionResult versionResult = context.repositorySystem()
                     .resolveVersion(
                             context.repositorySystemSession(),

--- a/runtime/standalone-static/pom.xml
+++ b/runtime/standalone-static/pom.xml
@@ -112,5 +112,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
@@ -67,6 +67,11 @@ public class MemoizingRepositorySystemSupplierLookup extends RepositorySystemSup
         HashMap<String, Object> memoized = new HashMap<>();
         memoized.putAll(instances);
         memoized.putAll(staticExtensions.getOrDefault(key, Collections.emptyMap()));
+        // ensure map values are all subtypes of key
+        if (memoized.values().stream().anyMatch(v -> !key.isAssignableFrom(v.getClass()))) {
+            throw new IllegalArgumentException(
+                    String.format("User provided static extensions for key %s are of wrong type", key.getName()));
+        }
         plurals.put(key, memoized);
         return (Map) memoized;
     }

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/MemoizingRepositorySystemSupplierLookup.java
@@ -8,7 +8,11 @@
 package eu.maveniverse.maven.mima.runtime.standalonestatic;
 
 import eu.maveniverse.maven.mima.context.Lookup;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import org.apache.maven.model.building.ModelBuilder;
 import org.apache.maven.repository.internal.ModelCacheFactory;
 import org.eclipse.aether.RepositoryListener;
@@ -40,11 +44,12 @@ import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.eclipse.aether.transport.http.ChecksumExtractor;
 
 public class MemoizingRepositorySystemSupplierLookup extends RepositorySystemSupplier implements Lookup {
+    private final Map<Class<?>, Map<String, Object>> staticExtensions;
     private final HashMap<Class<?>, Object> singulars = new HashMap<>();
-
     private final HashMap<Class<?>, Map<String, Object>> plurals = new HashMap<>();
 
-    public MemoizingRepositorySystemSupplierLookup() {
+    public MemoizingRepositorySystemSupplierLookup(Map<Class<?>, Map<String, Object>> staticExtensions) {
+        this.staticExtensions = staticExtensions;
         memoize(RepositorySystem.class, super.get()); // to trigger filling up of memoized components
     }
 
@@ -58,10 +63,12 @@ public class MemoizingRepositorySystemSupplierLookup extends RepositorySystemSup
         return instance;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
     protected <T> Map<String, T> memoize(Class<T> key, Map<String, T> instances) {
-        plurals.put(key, (Map) instances);
-        return instances;
+        HashMap<String, Object> memoized = new HashMap<>();
+        memoized.putAll(instances);
+        memoized.putAll(staticExtensions.getOrDefault(key, Collections.emptyMap()));
+        plurals.put(key, memoized);
+        return (Map) memoized;
     }
 
     @Override

--- a/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntime.java
+++ b/runtime/standalone-static/src/main/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntime.java
@@ -63,7 +63,8 @@ public class StandaloneStaticRuntime extends StandaloneRuntimeSupport {
     }
 
     protected Lookup createRepositorySystemLookup(PreBoot preBoot) {
-        return new MemoizingRepositorySystemSupplierLookup();
+        return new MemoizingRepositorySystemSupplierLookup(
+                preBoot.getOverrides().getStaticExtensions());
     }
 
     protected Lookup createCompatLookup(PreBoot preBoot) {

--- a/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
+++ b/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
@@ -97,4 +97,27 @@ public class StandaloneStaticRuntimeTest {
             assertTrue(e.getMessage().contains("trusted checksum mismatch"), e.getMessage());
         }
     }
+
+    @Test
+    void smokeWithBadExtensions() {
+        // set up static extensions
+        HashMap<String, Object> trustedSources = new HashMap<>();
+        trustedSources.put("fake", "this should not be a string but a TrustedChecksumsSource instance");
+        HashMap<Class<?>, Map<String, Object>> extensions = new HashMap<>();
+        extensions.put(TrustedChecksumsSource.class, trustedSources);
+
+        StandaloneStaticRuntime runtime = new StandaloneStaticRuntime();
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withLocalRepositoryOverride(Paths.get("target/local-repo"))
+                .withStaticExtensions(extensions)
+                .build())) {
+            fail("Context creation should have fail");
+        } catch (IllegalArgumentException e) {
+            assertTrue(
+                    e.getMessage()
+                            .contains(
+                                    "User provided static extensions for key org.eclipse.aether.spi.checksums.TrustedChecksumsSource are of wrong type"),
+                    e.getMessage());
+        }
+    }
 }

--- a/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
+++ b/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import eu.maveniverse.maven.mima.context.Context;
 import eu.maveniverse.maven.mima.context.ContextOverrides;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -78,6 +79,7 @@ public class StandaloneStaticRuntimeTest {
 
         StandaloneStaticRuntime runtime = new StandaloneStaticRuntime();
         try (Context context = runtime.create(ContextOverrides.create()
+                .withLocalRepositoryOverride(Paths.get("target/local-repo"))
                 .withStaticExtensions(extensions)
                 .userProperties(userProperties)
                 .build())) {

--- a/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
+++ b/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
@@ -100,7 +100,7 @@ public class StandaloneStaticRuntimeTest {
 
     @Test
     void smokeWithBadExtensions() {
-        // set up static extensions
+        // set up static extensions with bad type (of type String, but key is TrustedChecksumsSource)
         HashMap<String, Object> trustedSources = new HashMap<>();
         trustedSources.put("fake", "this should not be a string but a TrustedChecksumsSource instance");
         HashMap<Class<?>, Map<String, Object>> extensions = new HashMap<>();

--- a/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
+++ b/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
@@ -35,7 +35,9 @@ public class StandaloneStaticRuntimeTest {
     @Test
     void smoke() {
         StandaloneStaticRuntime runtime = new StandaloneStaticRuntime();
-        try (Context context = runtime.create(ContextOverrides.create().build())) {
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withLocalRepositoryOverride(Paths.get("target/local-repo"))
+                .build())) {
             VersionResult versionResult = context.repositorySystem()
                     .resolveVersion(
                             context.repositorySystemSession(),

--- a/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
+++ b/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023-2026 Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.mima.runtime.standalonestatic;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import eu.maveniverse.maven.mima.context.Context;
+import eu.maveniverse.maven.mima.context.ContextOverrides;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.ArtifactRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionResult;
+import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.junit.jupiter.api.Test;
+
+public class StandaloneStaticRuntimeTest {
+    @Test
+    void smoke() {
+        StandaloneStaticRuntime runtime = new StandaloneStaticRuntime();
+        try (Context context = runtime.create(ContextOverrides.create().build())) {
+            VersionResult versionResult = context.repositorySystem()
+                    .resolveVersion(
+                            context.repositorySystemSession(),
+                            new VersionRequest(
+                                    new DefaultArtifact("eu.maveniverse.maven.mima:context:LATEST"),
+                                    context.remoteRepositories(),
+                                    "test"));
+            // dynamic version should be resolved to some static version
+            assertNotEquals("LATEST", versionResult.getVersion());
+        } catch (VersionResolutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void smokeWithExtensions() {
+        TrustedChecksumsSource fakeSource = new TrustedChecksumsSource() {
+            @Override
+            public Map<String, String> getTrustedArtifactChecksums(
+                    RepositorySystemSession session,
+                    Artifact artifact,
+                    ArtifactRepository artifactRepository,
+                    List<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
+                return Collections.singletonMap("SHA-1", "fake");
+            }
+
+            @Override
+            public Writer getTrustedArtifactChecksumsWriter(RepositorySystemSession session) {
+                return null;
+            }
+        };
+        // set up static extensions
+        HashMap<String, Object> trustedSources = new HashMap<>();
+        trustedSources.put("fake", fakeSource);
+        HashMap<Class<?>, Map<String, Object>> extensions = new HashMap<>();
+        extensions.put(TrustedChecksumsSource.class, trustedSources);
+        // set up configuration
+        HashMap<String, String> userProperties = new HashMap<>();
+        userProperties.put("aether.artifactResolver.postProcessor.trustedChecksums", "true");
+        userProperties.put("aether.artifactResolver.postProcessor.trustedChecksums.checksumAlgorithms", "SHA-1");
+
+        StandaloneStaticRuntime runtime = new StandaloneStaticRuntime();
+        try (Context context = runtime.create(ContextOverrides.create()
+                .withStaticExtensions(extensions)
+                .userProperties(userProperties)
+                .build())) {
+            ArtifactResult artifactResult = context.repositorySystem()
+                    .resolveArtifact(
+                            context.repositorySystemSession(),
+                            new ArtifactRequest(
+                                    new DefaultArtifact("eu.maveniverse.maven.mima:context:2.4.45"),
+                                    context.remoteRepositories(),
+                                    "test"));
+        } catch (ArtifactResolutionException e) {
+            assertTrue(e.getMessage().contains("trusted checksum mismatch"), e.getMessage());
+        }
+    }
+}

--- a/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
+++ b/runtime/standalone-static/src/test/java/eu/maveniverse/maven/mima/runtime/standalonestatic/StandaloneStaticRuntimeTest.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.mima.runtime.standalonestatic;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import eu.maveniverse.maven.mima.context.Context;
 import eu.maveniverse.maven.mima.context.ContextOverrides;
@@ -22,7 +23,6 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.ArtifactRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
-import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.resolution.VersionRequest;
 import org.eclipse.aether.resolution.VersionResolutionException;
 import org.eclipse.aether.resolution.VersionResult;
@@ -81,13 +81,14 @@ public class StandaloneStaticRuntimeTest {
                 .withStaticExtensions(extensions)
                 .userProperties(userProperties)
                 .build())) {
-            ArtifactResult artifactResult = context.repositorySystem()
+            context.repositorySystem()
                     .resolveArtifact(
                             context.repositorySystemSession(),
                             new ArtifactRequest(
                                     new DefaultArtifact("eu.maveniverse.maven.mima:context:2.4.45"),
                                     context.remoteRepositories(),
                                     "test"));
+            fail("Resolution should have fail");
         } catch (ArtifactResolutionException e) {
             assertTrue(e.getMessage().contains("trusted checksum mismatch"), e.getMessage());
         }


### PR DESCRIPTION
Provide a means for user to inject "static extensions". This is used (and needed) only in static-runtime, as with sisu-runtime the usual component discovery should be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose and configure static extensions so static implementations can be merged with runtime-provided instances.

* **Tests**
  * Added integration tests for standalone runtimes covering version resolution, static extensions, checksum validation, and type-validation failures.

* **Chores**
  * Added test-scoped JUnit and simple SLF4J logging dependencies for test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->